### PR TITLE
Parsing to int when reading AndesConfiguration value MANAGEMENT_CONSOLE_MAX_DISPLAY_LENGTH_FOR_MESSAGE_CONTENT

### DIFF
--- a/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/internal/util/Utils.java
+++ b/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/internal/util/Utils.java
@@ -75,7 +75,7 @@ public class Utils {
     /**
      * Maximum size a message will be displayed on UI
      */
-    public static final int MESSAGE_DISPLAY_LENGTH_MAX = AndesConfigurationManager.readValue(AndesConfiguration.MANAGEMENT_CONSOLE_MAX_DISPLAY_LENGTH_FOR_MESSAGE_CONTENT);
+    public static final int MESSAGE_DISPLAY_LENGTH_MAX = Integer.parseInt(String.valueOf(AndesConfigurationManager.readValue(AndesConfiguration.MANAGEMENT_CONSOLE_MAX_DISPLAY_LENGTH_FOR_MESSAGE_CONTENT)));
 
     /**
      * Shown to user has a indication that the particular message has more content than shown in UI


### PR DESCRIPTION
Parsing to int when reading AndesConfiguration value MANAGEMENT_CONSOLE_MAX_DISPLAY_LENGTH_FOR_MESSAGE_CONTENT