### PR TITLE
Disruptor upgrade to version 3.3.0.wso2v1

### DIFF
--- a/features/andes/org.wso2.carbon.andes.server.feature/pom.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/pom.xml
@@ -71,7 +71,7 @@
             <artifactId>commons-cli</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.disruptor.wso2</groupId>
+            <groupId>org.wso2.lmax</groupId>
             <artifactId>disruptor</artifactId>
         </dependency>
         <dependency>
@@ -170,7 +170,7 @@
                                 <bundleDef>org.wso2.carbon.messaging:org.wso2.carbon.andes.admin:${carbon.messaging.version}</bundleDef>
                                 <bundleDef>org.wso2.carbon.messaging:org.wso2.carbon.andes.cluster.mgt:${carbon.messaging.version}</bundleDef>
                                 <bundleDef>org.wso2.andes.wso2:andes:${andes.dependency.version}</bundleDef>
-                                <bundleDef>com.googlecode.disruptor.wso2:disruptor</bundleDef>
+                                <bundleDef>org.wso2.lmax:disruptor</bundleDef>
                                 <bundleDef>commons-cli.wso2:commons-cli</bundleDef>
                                 <bundleDef>commons-configuration.wso2:commons-configuration</bundleDef>
                                 <bundleDef>commons-digester.wso2:commons-digester</bundleDef>

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -64,6 +64,17 @@ expression of the property. -->
             <!-- put proper default SSL port -->
             <sslPort>8883</sslPort>
             <!-- These two properties are temporary. Ideally, MQTT should use carbon users. -->
+
+            <!--Ring buffer size of MQTT inbound event disruptor. Default is set to 32768 (1024 * 32)
+            Having a large ring buffer will have a increase memory usage and will improve performance
+            and wise versa -->
+            <inboundBufferSize>32768</inboundBufferSize>
+
+            <!--Ring buffer size of MQTT delivery event disruptor. Default is set to 32768 (1024 * 32)
+            Having a large ring buffer will have a increase memory usage and will improve performance
+            and wise versa -->
+            <deliveryBufferSize>32768</deliveryBufferSize>
+            
             <users>
                 <user userName="testuser1" password="password1" />
                 <user userName="testuser2" password="password2" />

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -67,12 +67,12 @@ expression of the property. -->
 
             <!--Ring buffer size of MQTT inbound event disruptor. Default is set to 32768 (1024 * 32)
             Having a large ring buffer will have a increase memory usage and will improve performance
-            and wise versa -->
+            and vise versa -->
             <inboundBufferSize>32768</inboundBufferSize>
 
             <!--Ring buffer size of MQTT delivery event disruptor. Default is set to 32768 (1024 * 32)
             Having a large ring buffer will have a increase memory usage and will improve performance
-            and wise versa -->
+            and vise versa -->
             <deliveryBufferSize>32768</deliveryBufferSize>
             
             <users>
@@ -90,12 +90,12 @@ expression of the property. -->
     2. To persist and access other information relevant to messaging protocols.("contextStore").-->
 
     <!-- By default WSO2 MB runs with H2 persistent store. If you plan to use a different
-    store, point to the relevant dataSource or uncomment the database apprpriately.
+    store, point to the relevant dataSource or uncomment the database appropriately.
 
     RDBMS
     =====
     If you are running an RDBMS you can use the existing RDBMS implementation of stores
-    by pointing to the correct data source by updateing the property "dataSource".
+    by pointing to the correct data source by updating the property "dataSource".
 
     Data source entry should be present in
     <MB_HOME>/repository/conf/datasources/master-datasources.xml.
@@ -262,7 +262,7 @@ expression of the property. -->
         <ackHandling>
             <!--Number of message acknowledgement handlers to process acknowledgements concurrently.
             These acknowledgement handlers will batch and process acknowledgements.  -->
-            <ackHandlerCount>5</ackHandlerCount>
+            <ackHandlerCount>1</ackHandlerCount>
 
             <!--Maximum batch size of the acknowledgement handler. Andes process acknowledgements in
             batches using Disruptor Increasing the batch size reduces the number of calls made to
@@ -336,11 +336,14 @@ expression of the property. -->
         <!--Maximum number of messages to be fetched using Andes message browser when browsing
         queues -->
         <messageBatchSizeForBrowserSubscriptions>200</messageBatchSizeForBrowserSubscriptions>
-        <!-- This property defines the maximum message content length that can be displayed at the management console when
-        browsing queues. If the message length exceeds the value, a truncated content will be displayed with a statement
-        "message content too large to display." at the end. default value is 100000 (can roughly display a 100KB message.)
+
+        <!-- This property defines the maximum message content length that can be displayed at the
+        management console when browsing queues. If the message length exceeds the value, a
+        truncated content will be displayed with a statement "message content too large to display."
+        at the end. default value is 100000 (can roughly display a 100KB message.)
         * NOTE : Increasing this value could cause delays when loading the message content page.-->
         <maximumMessageDisplayLength>100000</maximumMessageDisplayLength>
+
     </managementConsole>
 
     <!-- Memory and resource exhaustion is something we should prevent and recover from.

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/qpid-config.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/qpid-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
-  ~ Copyright (c) 2005-2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~   WSO2 Inc. licenses this file to you under the Apache License,
   ~   Version 2.0 (the "License"); you may not use this file except
@@ -28,7 +28,7 @@
     <connector>
         <!-- To enable SSL edit the keystorePath and keystorePassword
      and set enabled to true.
-             To disasble Non-SSL port set sslOnly to true -->
+             To disable Non-SSL port set sslOnly to true -->
         <ssl>
             <enabled>true</enabled>
             <sslOnly>false</sslOnly>

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/qpid-virtualhosts.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/qpid-virtualhosts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
-  ~ Copyright (c) 2005-2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~   WSO2 Inc. licenses this file to you under the Apache License,
   ~   Version 2.0 (the "License"); you may not use this file except
@@ -42,13 +42,24 @@
             </exchanges>
 
             <queues>
-                <!--  Size in bytes when the sizes of all messages accumulated in a particular queue which leads to generate the notifications, By setting it to 0 , we switch it off , If we are setting it to 4MB , we need to put 4235264  -->
+                <!--  Size in bytes when the sizes of all messages accumulated in a particular queue 
+                which leads to generate the notifications, By setting it to 0 , we switch it off , If 
+                we are setting it to 4MB , we need to put 4235264  -->
                 <maximumQueueDepth>0</maximumQueueDepth>
-                <!--  Size in bytes when the sizes of a particular messages  which leads to generate the notifications, By setting it to 0 , we switch it off , If we are setting it to 2MB , we need to put 2117632  -->
+                
+                <!--  Size in bytes when the sizes of a particular messages  which leads to generate 
+                the notifications, By setting it to 0 , we switch it off , If we are setting it to 2MB,
+                 we need to put 2117632  -->
                 <maximumMessageSize>0</maximumMessageSize>
-                <!-- Time of a message which can be stayed in the server without delivering which leads to generate the notification, By setting it to 0 , we switch it off. If we are setting it to 1hr , we need to put 3600000  -->
+                
+                <!-- Time of a message which can be stayed in the server without delivering which leads 
+                to generate the notification, By setting it to 0 , we switch it off. If we are setting 
+                it to 1hr , we need to put 3600000  -->
                 <maximumMessageAge>0</maximumMessageAge>
-                <!-- Maximum message count of a queue which leads to generate the notofication,By setting it to 0 , we switch it off. If we are setting it to 50000 , we need to put 50000 -->
+                
+                <!-- Maximum message count of a queue which leads to generate the notification, By 
+                setting it to 0 , we switch it off. If we are setting it to 50000 , we need to put 50000 
+                -->
                 <maximumMessageCount>0</maximumMessageCount>
             </queues>
         </carbon>

--- a/pom.xml
+++ b/pom.xml
@@ -372,11 +372,10 @@ considered very carefully. -->
                 <artifactId>commons-lang</artifactId>
                 <version>2.6.0.wso2v1</version>
             </dependency>
-
             <dependency>
-                <groupId>com.googlecode.disruptor.wso2</groupId>
+                <groupId>org.wso2.lmax</groupId>
                 <artifactId>disruptor</artifactId>
-                <version>2.10.4-wso2v2</version>
+                <version>3.3.0.wso2v1</version>
             </dependency>
             <dependency>
                 <groupId>commons-digester.wso2</groupId>


### PR DESCRIPTION
- New configuration values for MQTT ring buffers in broker.xml.
- poms updated for Disruptor update.