### PR TITLE
[MB-1077] add meaningful log message with amqp host address/port.

### DIFF
--- a/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
+++ b/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
@@ -366,10 +366,9 @@ public class QpidServiceComponent {
             while (!isServerStarted) {
                 Socket socket = null;
                 try {
-                    log.info("Carbon Host Name : " + getTransportBindAddress());
                     InetAddress address = InetAddress.getByName(getTransportBindAddress());
                     socket = new Socket(address, port);
-                    log.info("Host : " + address.getHostAddress() + " port : " + port);
+                    log.info("AMQP Host Address : " + address.getHostAddress() + " Port : " + port);
                     isServerStarted = socket.isConnected();
                     if (isServerStarted) {
                         log.info("WSO2 Message Broker is Started. Successfully connected to the server on port " +


### PR DESCRIPTION
This pr is related to following jira issue[1]. this will add meaningful log info when displaying amqp host address and port while start up the server.

[1] https://wso2.org/jira/browse/MB-1077