### PR TITLE
[MB-1159][MB-1124] bind address per transport related fixes

### DIFF
--- a/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/internal/util/Utils.java
+++ b/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/internal/util/Utils.java
@@ -322,7 +322,7 @@ public class Utils {
 
         // getting host address from andes configuration mentioned in broker.xml
         String andesConfigHostAddress =
-                String.valueOf(AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_BIND_ADDRESS));
+                String.valueOf(AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_BIND_ADDRESS));
         String hostAddress = InetAddress.getByName(andesConfigHostAddress).getHostAddress();
 
         // getting port from andes configuration mentioned in broker.xml

--- a/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
+++ b/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
@@ -336,110 +336,6 @@ public class QpidServiceComponent {
 
 
     /**
-     * check whether the tcp port has started. some times the server started thread may return
-     * before Qpid server actually bind to the tcp port. in that case there are some connection
-     * time out issues.
-     *
-     * @throws ConfigurationException
-     */
-    private void startAMQPServer() throws ConfigurationException {
-
-        boolean isServerStarted = false;
-        int port;
-        if (qpidServiceImpl.getIfSSLOnly()) {
-            port = qpidServiceImpl.getAMQPSSLPort();
-        } else {
-            port = qpidServiceImpl.getAMQPPort();
-        }
-
-        if (AndesConfigurationManager.<Boolean>readValue(AndesConfiguration.TRANSPORTS_AMQP_ENABLED)) {
-            while (!isServerStarted) {
-                Socket socket = null;
-                try {
-                    InetAddress address = InetAddress.getByName(getAMQPTransportBindAddress());
-                    socket = new Socket(address, port);
-                    log.info("AMQP Host Address : " + address.getHostAddress() + " Port : " + port);
-                    isServerStarted = socket.isConnected();
-                    if (isServerStarted) {
-                        log.info("WSO2 Message Broker is Started. Successfully connected to AMQP server "
-                                 + "on port " + port);
-                    }
-                } catch (IOException e) {
-                    log.error("Wait until Qpid server starts on port " + port, e);
-                    try {
-                        Thread.sleep(500);
-                    } catch (InterruptedException ignore) {
-                        // Ignore
-                    }
-                } finally {
-                    try {
-                        if ((socket != null) && (socket.isConnected())) {
-                            socket.close();
-                        }
-                    } catch (IOException e) {
-                        log.error("Can not close the socket which is used to check the server " +
-                                "status ", e);
-                    }
-                }
-            }
-        } else {
-            log.warn("AMQP Transport is disabled as per configuration.");
-        }
-    }
-
-    /**
-     * check whether the tcp port has started. some times the server started thread may return
-     * before MQTT server actually bind to the tcp port. in that case there are some connection
-     * time out issues.
-     *
-     * @throws ConfigurationException
-     */
-    private void startMQTTServer() throws ConfigurationException {
-
-        boolean isServerStarted = false;
-        int port;
-
-        if (qpidServiceImpl.getIfSSLOnly()) {
-            port = qpidServiceImpl.getMqttSSLPort();
-        } else {
-            port = qpidServiceImpl.getMqttPort();
-        }
-
-        if (AndesConfigurationManager.<Boolean>readValue(AndesConfiguration.TRANSPORTS_MQTT_ENABLED)) {
-            while (!isServerStarted) {
-                Socket socket = null;
-                try {
-                    InetAddress address = InetAddress.getByName(getMQTTTransportBindAddress());
-                    socket = new Socket(address, port);
-                    log.info("MQTT Host Address : " + address.getHostAddress() + " Port : " + port);
-                    isServerStarted = socket.isConnected();
-                    if (isServerStarted) {
-                        log.info("Successfully connected to the MQTT server on port " + port);
-                    }
-                } catch (IOException e) {
-                    log.error("Wait until server starts on port " + port, e);
-                    try {
-                        Thread.sleep(500);
-                    } catch (InterruptedException ignore) {
-                        // Ignore
-                    }
-                } finally {
-                    try {
-                        if ((socket != null) && (socket.isConnected())) {
-                            socket.close();
-                        }
-                    } catch (IOException e) {
-                        log.error("Can not close the socket which is used to check the server " +
-                                  "status ", e);
-                    }
-                }
-            }
-        } else {
-            log.warn("MQTT Transport is disabled as per configuration.");
-        }
-    }
-
-    /**
      * Start Andes Broker and related components with given configurations.
      *
      * @throws ConfigurationException
@@ -509,4 +405,112 @@ public class QpidServiceComponent {
         QpidServiceDataHolder.getInstance().getEventBundleNotificationService().notifyStart(qpidServerDetails);
 
     }
+
+    
+
+    /**
+     * check whether the tcp port has started. some times the server started thread may return
+     * before Qpid server actually bind to the tcp port. in that case there are some connection
+     * time out issues.
+     *
+     * @throws ConfigurationException
+     */
+    private void startAMQPServer() throws ConfigurationException {
+
+        boolean isServerStarted = false;
+        int port;
+        if (qpidServiceImpl.getIfSSLOnly()) {
+            port = qpidServiceImpl.getAMQPSSLPort();
+        } else {
+            port = qpidServiceImpl.getAMQPPort();
+        }
+
+        if (AndesConfigurationManager.<Boolean>readValue(AndesConfiguration.TRANSPORTS_AMQP_ENABLED)) {
+            while (!isServerStarted) {
+                Socket socket = null;
+                try {
+                    InetAddress address = InetAddress.getByName(getAMQPTransportBindAddress());
+                    socket = new Socket(address, port);
+                    log.info("AMQP Host Address : " + address.getHostAddress() + " Port : " + port);
+                    isServerStarted = socket.isConnected();
+                    if (isServerStarted) {
+                        log.info("WSO2 Message Broker is Started. Successfully connected to AMQP server "
+                                 + "on port " + port);
+                    }
+                } catch (IOException e) {
+                    log.error("Wait until Qpid server starts on port " + port, e);
+                    try {
+                        Thread.sleep(500);
+                    } catch (InterruptedException ignore) {
+                        // Ignore
+                    }
+                } finally {
+                    try {
+                        if ((socket != null) && (socket.isConnected())) {
+                            socket.close();
+                        }
+                    } catch (IOException e) {
+                        log.error("Can not close the socket which is used to check the server " +
+                                  "status ", e);
+                    }
+                }
+            }
+        } else {
+            log.warn("AMQP Transport is disabled as per configuration.");
+        }
+    }
+
+
+    /**
+     * check whether the tcp port has started. some times the server started thread may return
+     * before MQTT server actually bind to the tcp port. in that case there are some connection
+     * time out issues.
+     *
+     * @throws ConfigurationException
+     */
+    private void startMQTTServer() throws ConfigurationException {
+
+        boolean isServerStarted = false;
+        int port;
+
+        if (qpidServiceImpl.getIfSSLOnly()) {
+            port = qpidServiceImpl.getMqttSSLPort();
+        } else {
+            port = qpidServiceImpl.getMqttPort();
+        }
+
+        if (AndesConfigurationManager.<Boolean>readValue(AndesConfiguration.TRANSPORTS_MQTT_ENABLED)) {
+            while (!isServerStarted) {
+                Socket socket = null;
+                try {
+                    InetAddress address = InetAddress.getByName(getMQTTTransportBindAddress());
+                    socket = new Socket(address, port);
+                    log.info("MQTT Host Address : " + address.getHostAddress() + " Port : " + port);
+                    isServerStarted = socket.isConnected();
+                    if (isServerStarted) {
+                        log.info("Successfully connected to the MQTT server on port " + port);
+                    }
+                } catch (IOException e) {
+                    log.error("Wait until server starts on port " + port, e);
+                    try {
+                        Thread.sleep(500);
+                    } catch (InterruptedException ignore) {
+                        // Ignore
+                    }
+                } finally {
+                    try {
+                        if ((socket != null) && (socket.isConnected())) {
+                            socket.close();
+                        }
+                    } catch (IOException e) {
+                        log.error("Can not close the socket which is used to check the server " +
+                                  "status ", e);
+                    }
+                }
+            }
+        } else {
+            log.warn("MQTT Transport is disabled as per configuration.");
+        }
+    }
+
 }

--- a/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
+++ b/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
@@ -316,6 +316,135 @@ public class QpidServiceComponent {
 
     }
 
+    /***
+     * This applies the MQTTbindAddress from broker.xml instead of the hostname from carbon.xml within MB.
+     * @return host name as derived from broker.xml
+     */
+    private String getMQTTTransportBindAddress() {
+        return AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_MQTT_BIND_ADDRESS);
+
+    }
+
+    /***
+     * This applies the AMQPbindAddress from broker.xml instead of the hostname from carbon.xml within MB.
+     * @return host name as derived from broker.xml
+     */
+    private String getAMQPTransportBindAddress() {
+        return AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_BIND_ADDRESS);
+
+    }
+
+
+    /**
+     * check whether the tcp port has started. some times the server started thread may return
+     * before Qpid server actually bind to the tcp port. in that case there are some connection
+     * time out issues.
+     *
+     * @throws ConfigurationException
+     */
+    private void startAMQPServer() throws ConfigurationException {
+
+        boolean isServerStarted = false;
+        int port;
+        if (qpidServiceImpl.getIfSSLOnly()) {
+            port = qpidServiceImpl.getAMQPSSLPort();
+        } else {
+            port = qpidServiceImpl.getAMQPPort();
+        }
+
+        if (AndesConfigurationManager.<Boolean>readValue(AndesConfiguration.TRANSPORTS_AMQP_ENABLED)) {
+            while (!isServerStarted) {
+                Socket socket = null;
+                try {
+                    InetAddress address = InetAddress.getByName(getAMQPTransportBindAddress());
+                    socket = new Socket(address, port);
+                    log.info("AMQP Host Address : " + address.getHostAddress() + " Port : " + port);
+                    isServerStarted = socket.isConnected();
+                    if (isServerStarted) {
+                        log.info("WSO2 Message Broker is Started. Successfully connected to AMQP server "
+                                 + "on port " + port);
+                    }
+                } catch (IOException e) {
+                    log.error("Wait until Qpid server starts on port " + port, e);
+                    try {
+                        Thread.sleep(500);
+                    } catch (InterruptedException ignore) {
+                        // Ignore
+                    }
+                } finally {
+                    try {
+                        if ((socket != null) && (socket.isConnected())) {
+                            socket.close();
+                        }
+                    } catch (IOException e) {
+                        log.error("Can not close the socket which is used to check the server " +
+                                "status ", e);
+                    }
+                }
+            }
+        } else {
+            log.warn("AMQP Transport is disabled as per configuration.");
+        }
+    }
+
+    /**
+     * check whether the tcp port has started. some times the server started thread may return
+     * before MQTT server actually bind to the tcp port. in that case there are some connection
+     * time out issues.
+     *
+     * @throws ConfigurationException
+     */
+    private void startMQTTServer() throws ConfigurationException {
+
+        boolean isServerStarted = false;
+        int port;
+
+        if (qpidServiceImpl.getIfSSLOnly()) {
+            port = qpidServiceImpl.getMqttSSLPort();
+        } else {
+            port = qpidServiceImpl.getMqttPort();
+        }
+
+        if (AndesConfigurationManager.<Boolean>readValue(AndesConfiguration.TRANSPORTS_MQTT_ENABLED)) {
+            while (!isServerStarted) {
+                Socket socket = null;
+                try {
+                    InetAddress address = InetAddress.getByName(getMQTTTransportBindAddress());
+                    socket = new Socket(address, port);
+                    log.info("MQTT Host Address : " + address.getHostAddress() + " Port : " + port);
+                    isServerStarted = socket.isConnected();
+                    if (isServerStarted) {
+                        log.info("Successfully connected to the MQTT server on port " + port);
+                    }
+                } catch (IOException e) {
+                    log.error("Wait until server starts on port " + port, e);
+                    try {
+                        Thread.sleep(500);
+                    } catch (InterruptedException ignore) {
+                        // Ignore
+                    }
+                } finally {
+                    try {
+                        if ((socket != null) && (socket.isConnected())) {
+                            socket.close();
+                        }
+                    } catch (IOException e) {
+                        log.error("Can not close the socket which is used to check the server " +
+                                  "status ", e);
+                    }
+                }
+            }
+        } else {
+            log.warn("MQTT Transport is disabled as per configuration.");
+        }
+    }
+
+    /**
+     * Start Andes Broker and related components with given configurations.
+     *
+     * @throws ConfigurationException
+     * @throws AndesException
+     */
     private void startAndesBroker() throws ConfigurationException, AndesException {
         brokerShouldBeStarted = false;
 
@@ -352,49 +481,15 @@ public class QpidServiceComponent {
             }
         }
 
-        //check whether the tcp port has started. some times the server started thread may return
-        //before Qpid server actually bind to the tcp port. in that case there are some connection
-        //time out issues.
-        boolean isServerStarted = false;
-        int port;
-        if (qpidServiceImpl.getIfSSLOnly()) {
-            port = qpidServiceImpl.getAMQPSSLPort();
-        } else {
-            port = qpidServiceImpl.getAMQPPort();
-        }
-        if (AndesConfigurationManager.<Boolean>readValue(AndesConfiguration.TRANSPORTS_AMQP_ENABLED)) {
-            while (!isServerStarted) {
-                Socket socket = null;
-                try {
-                    InetAddress address = InetAddress.getByName(getTransportBindAddress());
-                    socket = new Socket(address, port);
-                    log.info("AMQP Host Address : " + address.getHostAddress() + " Port : " + port);
-                    isServerStarted = socket.isConnected();
-                    if (isServerStarted) {
-                        log.info("WSO2 Message Broker is Started. Successfully connected to the server on port " +
-                                port);
-                    }
-                } catch (IOException e) {
-                    log.error("Wait until Qpid server starts on port " + port, e);
-                    try {
-                        Thread.sleep(500);
-                    } catch (InterruptedException ignore) {
-                        // Ignore
-                    }
-                } finally {
-                    try {
-                        if ((socket != null) && (socket.isConnected())) {
-                            socket.close();
-                        }
-                    } catch (IOException e) {
-                        log.error("Can not close the socket which is used to check the server " +
-                                "status ", e);
-                    }
-                }
-            }
-        } else {
-            log.warn("AMQP Transport is disabled as per configuration.");
-        }
+        // TODO: Have to re-structure how andes broker getting started.
+        // there should be a separate andes-core component to initialize Andes Broker. Within
+        // that component both Qpid and MQTT components should initialized.
+
+        // Start AMQP server with given configurations
+        startAMQPServer();
+
+        // Start MQTT Server with given configurations
+        startMQTTServer();
 
         // Publish Qpid properties
         registrations.push(bundleContext.registerService(

--- a/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
+++ b/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
@@ -406,7 +406,7 @@ public class QpidServiceComponent {
 
     }
 
-    
+
 
     /**
      * check whether the tcp port has started. some times the server started thread may return
@@ -450,8 +450,8 @@ public class QpidServiceComponent {
                             socket.close();
                         }
                     } catch (IOException e) {
-                        log.error("Can not close the socket which is used to check the server " +
-                                  "status ", e);
+                        log.error("Can not close the socket which is used to check the server "
+                                  + "status ", e);
                     }
                 }
             }
@@ -503,8 +503,8 @@ public class QpidServiceComponent {
                             socket.close();
                         }
                     } catch (IOException e) {
-                        log.error("Can not close the socket which is used to check the server " +
-                                  "status ", e);
+                        log.error("Can not close the socket which is used to check the server "
+                                  + "status ", e);
                     }
                 }
             }

--- a/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/service/QpidServiceImpl.java
+++ b/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/service/QpidServiceImpl.java
@@ -116,7 +116,7 @@ public class QpidServiceImpl implements QpidService {
     public void loadConfigurations() {
         // Get the hostname that Carbon runs on
         String andesConfigHostAddress =
-                String.valueOf(AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_BIND_ADDRESS));
+                String.valueOf(AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_BIND_ADDRESS));
         if (StringUtils.isNotBlank(andesConfigHostAddress)) {
             try {
                 hostname = InetAddress.getByName(andesConfigHostAddress).getHostAddress();

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -47,11 +47,6 @@ expression of the property. -->
     transports are enabled. This section also allows you to customize the messaging flows used 
     within WSO2 MB. NOT performance related, but logic related. -->
     <transports>
-        <!-- In a clustered setup this should be updated with the IP address of this node
-        Setting the value to 127.0.0.1 in a clustered setup is wrong. Please note that this is 
-        the address exposed by the server. NOT the hostname inferred from carbon.xml -->
-        <bindAddress>127.0.0.1</bindAddress>
-
         <amqp enabled="true">
             <bindAddress>localhost</bindAddress>
             <!-- most of the AMQP configurations reside in qpid-config.xml since we inherit the Qpid

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -48,16 +48,16 @@ expression of the property. -->
     within WSO2 MB. NOT performance related, but logic related. -->
     <transports>
         <amqp enabled="true">
-            <bindAddress>localhost</bindAddress>
             <!-- most of the AMQP configurations reside in qpid-config.xml since we inherit the Qpid
             messaging model during AMQP.-->
+            <bindAddress>0.0.0.0</bindAddress>
             <port>5672</port>
             <sslPort>8672</sslPort>
             <maximumRedeliveryAttempts>10</maximumRedeliveryAttempts>
             <allowSharedTopicSubscriptions>false</allowSharedTopicSubscriptions>
         </amqp>
         <mqtt enabled="true">
-            <bindAddress>localhost</bindAddress>
+            <bindAddress>0.0.0.0</bindAddress>
             <port>1883</port>
             <!-- put proper default SSL port -->
             <sslPort>8883</sslPort>

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -53,6 +53,7 @@ expression of the property. -->
         <bindAddress>127.0.0.1</bindAddress>
 
         <amqp enabled="true">
+            <bindAddress>localhost</bindAddress>
             <!-- most of the AMQP configurations reside in qpid-config.xml since we inherit the Qpid
             messaging model during AMQP.-->
             <port>5672</port>
@@ -61,6 +62,7 @@ expression of the property. -->
             <allowSharedTopicSubscriptions>false</allowSharedTopicSubscriptions>
         </amqp>
         <mqtt enabled="true">
+            <bindAddress>localhost</bindAddress>
             <port>1883</port>
             <!-- put proper default SSL port -->
             <sslPort>8883</sslPort>


### PR DESCRIPTION
This PR will fix following issues.
1. Added bind addresses per each transport. This change will enable AMQP and MQTT use separate bind addresses. There won't be a single bind address per server after this change[1].
2. Change AMQP and MQTT bind addresses 0.0.0.0 to bind all interfaces available[2].

[1] https://wso2.org/jira/browse/MB-1159
[2] https://wso2.org/jira/browse/MB-1124