### PR TITLE
Moving SSL configurations from qpid-config.xml to broker.xml

### DIFF
--- a/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/service/QpidServiceImpl.java
+++ b/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/service/QpidServiceImpl.java
@@ -337,7 +337,7 @@ public class QpidServiceImpl implements QpidService {
      * @return Port used for AMQP transports with offset if specified.
      */
     private Integer readPortFromConfig() {
-        return AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_PORT);
+        return AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_DEFAULT_CONNECTION_PORT);
     }
 
     /**
@@ -346,7 +346,7 @@ public class QpidServiceImpl implements QpidService {
      * @return The port value
      */
     private Integer readSSLPortFromConfig() {
-        return AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_SSL_PORT);
+        return AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_SSL_CONNECTION_PORT);
     }
 
     /**
@@ -355,7 +355,7 @@ public class QpidServiceImpl implements QpidService {
      * @return The port value
      */
     private Integer readMQTTPortFromConfig() {
-        return AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_MQTT_PORT);
+        return AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_MQTT_DEFAULT_CONNECTION_PORT);
 
     }
 
@@ -365,7 +365,7 @@ public class QpidServiceImpl implements QpidService {
      * @return The port value
      */
     private Integer readMQTTSSLPortFromConfig() {
-        return AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_MQTT_SSL_PORT);
+        return AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_MQTT_SSL_CONNECTION_PORT);
     }
 
     /**

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -25,11 +25,6 @@ relevant, org.wso2.andes.configuration.enums.AndesConfiguration, enum value usin
 expression of the property. -->
 <broker>
 
-    <!--Paths of externally organized configurations specific to Andes component (Qpid configurations
-    are referred by Qpid component separately. (MB_HOME/repository/conf/advanced/qpid-config.xml)-->
-    <links>
-    </links>
-
     <coordination>
         <!-- You can override the cluster node identifier of this MB node using the nodeID. 
         If it is left as "default", the default node ID will be generated for it. (Using IP + UUID).
@@ -48,20 +43,41 @@ expression of the property. -->
     within WSO2 MB. NOT performance related, but logic related. -->
     <transports>
         <amqp enabled="true">
-            <!-- most of the AMQP configurations reside in qpid-config.xml since we inherit the Qpid
-            messaging model during AMQP.-->
             <bindAddress>0.0.0.0</bindAddress>
-            <port>5672</port>
-            <sslPort>8672</sslPort>
+
+            <defaultConnection enabled="true" port="5672" />
+
+            <sslConnection enabled="true" port="8672">
+                <keyStore>
+                     <location>repository/resources/security/wso2carbon.jks</location>
+                     <password>wso2carbon</password>
+                </keyStore>
+                <trustStore>
+                    <location>repository/resources/security/client-truststore.jks</location>
+                    <password>wso2carbon</password>
+                </trustStore>
+            </sslConnection>
+
             <maximumRedeliveryAttempts>10</maximumRedeliveryAttempts>
             <allowSharedTopicSubscriptions>false</allowSharedTopicSubscriptions>
+
+            <!-- Refer repository/conf/advanced/qpid-config.xml for further AMQP-specific configurations.-->
         </amqp>
         <mqtt enabled="true">
             <bindAddress>0.0.0.0</bindAddress>
-            <port>1883</port>
-            <!-- put proper default SSL port -->
-            <sslPort>8883</sslPort>
-            <!-- These two properties are temporary. Ideally, MQTT should use carbon users. -->
+
+            <defaultConnection enabled="true" port="1883" />
+
+            <sslConnection enabled="true" port="8883">
+                <keyStore>
+                    <location>repository/resources/security/wso2carbon.jks</location>
+                    <password>wso2carbon</password>
+                </keyStore>
+                <trustStore>
+                    <location>repository/resources/security/client-truststore.jks</location>
+                    <password>wso2carbon</password>
+                </trustStore>
+            </sslConnection>
 
             <!--Ring buffer size of MQTT inbound event disruptor. Default is set to 32768 (1024 * 32)
             Having a large ring buffer will have a increase memory usage and will improve performance

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -22,7 +22,9 @@ associated libraries are also specified here.
 
 [Note for developers] - If you intend to rename or modify a property name, remember to update 
 relevant, org.wso2.andes.configuration.enums.AndesConfiguration, enum value using the Xpath 
-expression of the property. -->
+expression of the property.
+
+This file is ciphertool compliant. Refer PRODUCT_HOME/repository/conf/security/cipher-text.properties for examples.-->
 <broker>
 
     <coordination>

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/qpid-config.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/qpid-config.xml
@@ -26,17 +26,6 @@
     <cache-directory>${QPID_WORK}/cache</cache-directory>
 
     <connector>
-        <!-- To enable SSL edit the keystorePath and keystorePassword
-     and set enabled to true.
-             To disable Non-SSL port set sslOnly to true -->
-        <ssl>
-            <enabled>true</enabled>
-            <sslOnly>false</sslOnly>
-            <keystorePath>repository/resources/security/wso2carbon.jks</keystorePath>
-            <keystorePassword>wso2carbon</keystorePassword>
-            <truststorePath>repository/resources/security/client-truststore.jks</truststorePath>
-            <truststorePassword>wso2carbon</truststorePassword>
-        </ssl>
         <qpidnio>false</qpidnio>
         <protectio>
             <enabled>false</enabled>
@@ -44,8 +33,6 @@
             <writeBufferLimitSize>262144</writeBufferLimitSize>
         </protectio>
         <transport>nio</transport>
-        <!--<port>5672</port>
-        <sslport>8672</sslport--> <!-- These 2 properties have been moved to andes -> broker.xml for easier maintenance.-->
         <socketReceiveBuffer>32768</socketReceiveBuffer>
         <socketSendBuffer>32768</socketSendBuffer>
     </connector>


### PR DESCRIPTION
This is with reference to jiras : 

https://wso2.org/jira/browse/MB-924 
https://wso2.org/jira/browse/MB-1160

AMQP SSL configurations are now parsed through AndesConfiguration instead of ServerConfiguration (QPID code.)

Dependent on : https://github.com/wso2/andes/pull/219