### PR TITLE
Changed script so that queue name declarations have the same length

### DIFF
--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/dbscripts/h2-mb.sql
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/dbscripts/h2-mb.sql
@@ -107,7 +107,7 @@ CREATE TABLE IF NOT EXISTS MB_SLOT (
                         SLOT_ID bigint(11) NOT NULL AUTO_INCREMENT,
                         START_MESSAGE_ID bigint(20) NOT NULL,
                         END_MESSAGE_ID bigint(20) NOT NULL,
-                        STORAGE_QUEUE_NAME varchar(100) NOT NULL,
+                        STORAGE_QUEUE_NAME varchar(512) NOT NULL,
                         SLOT_STATE tinyint(4) NOT NULL DEFAULT '1',
                         ASSIGNED_NODE_ID varchar(512) DEFAULT NULL,
                         ASSIGNED_QUEUE_NAME varchar(512) DEFAULT NULL,

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/dbscripts/mssql-mb.sql
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/dbscripts/mssql-mb.sql
@@ -151,7 +151,7 @@ CREATE TABLE MB_SLOT (
                         SLOT_ID bigint IDENTITY(1,1) NOT NULL,
                         START_MESSAGE_ID bigint NOT NULL,
                         END_MESSAGE_ID bigint NOT NULL,
-                        STORAGE_QUEUE_NAME varchar(100) NOT NULL,
+                        STORAGE_QUEUE_NAME varchar(512) NOT NULL,
                         SLOT_STATE tinyint NOT NULL DEFAULT '1',
                         ASSIGNED_NODE_ID varchar(512) DEFAULT NULL,
                         ASSIGNED_QUEUE_NAME varchar(512) DEFAULT NULL,

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/dbscripts/mysql-mb.sql
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/dbscripts/mysql-mb.sql
@@ -106,7 +106,7 @@ CREATE TABLE IF NOT EXISTS MB_SLOT (
                         SLOT_ID bigint(11) NOT NULL AUTO_INCREMENT,
                         START_MESSAGE_ID bigint(20) NOT NULL,
                         END_MESSAGE_ID bigint(20) NOT NULL,
-                        STORAGE_QUEUE_NAME varchar(100) NOT NULL,
+                        STORAGE_QUEUE_NAME varchar(512) NOT NULL,
                         SLOT_STATE tinyint(4) NOT NULL DEFAULT '1',
                         ASSIGNED_NODE_ID varchar(512) DEFAULT NULL,
                         ASSIGNED_QUEUE_NAME varchar(512) DEFAULT NULL,


### PR DESCRIPTION
Some of the queue name declarations in the sql scripts had a length that is incompatible with the other declarations.

addresses the jira https://wso2.org/jira/browse/MB-1168