### PR TITLE
[MB-1226] Set UI message sender's JMS delivery mode to 2

### DIFF
--- a/components/andes/org.wso2.carbon.andes.ui/src/main/java/org/wso2/carbon/andes/ui/client/QueueSenderClient.java
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/java/org/wso2/carbon/andes/ui/client/QueueSenderClient.java
@@ -83,10 +83,6 @@ public class QueueSenderClient {
                 int priority = 4;
                 long time_to_live = 0;
 
-                // set delivery mode 1- non persistent, 2- persistent
-                if (request.getParameter("delivery_mode") == null) {
-                    delivery_mode = 1;
-                }
                 // set time to live
                 if (!request.getParameter("expire").equals("")) {
                     String expire_time = request.getParameter("expire");

--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/queue_message_sender.jsp
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/queue_message_sender.jsp
@@ -93,10 +93,7 @@
                     }
                     int delivery_mode = 2;
                     int priority = 4;
-                    // set delivery mode 1- non persistent, 2- persistent
-                    if (request.getParameter("delivery_mode") == null) {
-                        delivery_mode = 1;
-                    }
+
                     boolean success = stub.sendMessage(nameOfQueue, jms_type, cor_id, msg_count, message_txt, delivery_mode, priority, time_to_live);
                     if(success) {
                     %>


### PR DESCRIPTION
Addresses the jira https://wso2.org/jira/browse/MB-1226

The issue was caused by intentionally setting JMS delivery mode to 1 when a user publishes messages through the management console without deliberately setting the JMS delivery mode.