### PR TITLE
[MB-1290] Tenants can consume messages from super tenants queues when the queue name is same

### DIFF
--- a/components/andes/org.wso2.carbon.andes.authorization/src/main/java/org/wso2/carbon/andes/authorization/andes/AndesAuthorizationHandler.java
+++ b/components/andes/org.wso2.carbon.andes.authorization/src/main/java/org/wso2/carbon/andes/authorization/andes/AndesAuthorizationHandler.java
@@ -243,8 +243,11 @@ public class AndesAuthorizationHandler {
             String queueID = CommonsUtil.getQueueID(queueName);
 
             try {
-                // authorise if admin user
-                if (isTenantAdmin(username, userRealm, tenantDomain, queueName)) {
+                if (!isOwnDomain(tenantDomain, queueName)) {
+                    accessResult = Result.DENIED;
+
+                    // authorise if admin user
+                } else if (isTenantAdmin(username, userRealm, tenantDomain, queueName)) {
                     accessResult = Result.ALLOWED;
 
                     // authorise consume


### PR DESCRIPTION
Check if the user and the queue belong to the same domain before
doing other security checks

https://wso2.org/jira/browse/MB-1290