### PR TITLE
[MB-1295] Node info page access given only for admin permission

### DIFF
--- a/components/andes/org.wso2.carbon.andes.cluster.mgt.ui/src/main/resources/META-INF/component.xml
+++ b/components/andes/org.wso2.carbon.andes.cluster.mgt.ui/src/main/resources/META-INF/component.xml
@@ -27,7 +27,7 @@
             <order>32</order>
             <style-class>home</style-class>
             <icon>../andes-cluster-mgt/images/cluster_info.png</icon>
-            <require-permission>/permission/admin/login</require-permission>
+            <require-permission>/permission/admin</require-permission>
         </menu>
         <menu>
             <id>test_menu</id>
@@ -39,7 +39,7 @@
             <order>10</order>
             <style-class>manage</style-class>
             <icon>../andes-cluster-mgt/images/list.gif</icon>
-            <require-permission>/permission/admin/login</require-permission>
+            <require-permission>/permission/admin</require-permission>
         </menu>
 
 	</menus>


### PR DESCRIPTION
JIRA - https://wso2.org/jira/browse/MB-1295

Node info page access given only for admin permission and removed access for users with only login permission.