### PR TITLE
MB-1377 issue fixed.

### DIFF
--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/js/treecontrol.js
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/js/treecontrol.js
@@ -7,6 +7,8 @@ function addQueue(createdFrom) {
         error = "Queue name cannot be empty.\n";
     } else if (!isValidQueueName(topic.value)) {
         error = "Queue name cannot contain any of following symbols ~!@#;%^*()+={}|\<>\"',\n";
+    } else if (isContainTmpPrefix(topic.value)) {
+        error = "Queue name cannot start with tmp_ prefix.\n";
     }
     if (error != "") {
         CARBON.showErrorDialog(error);
@@ -17,6 +19,10 @@ function addQueue(createdFrom) {
 
 function isValidQueueName(queueName){
     return !/[~!@#;%^*()+={}|\<>"',]/g.test(queueName);
+}
+
+function isContainTmpPrefix(queueName) {
+    return queueName.startsWith("tmp_");
 }
 
 function addQueueAndAssignPermissions(queue, createdFrom) {


### PR DESCRIPTION
- Public jira url https://wso2.org/jira/browse/MB-1377. We create queue name with tmp_ prefix when non durable topic subscription added. Queue name with tmp_ prefix filtered in management console and not listing under queue. So as a fix, we are not allow to create queue name with tmp_ prefix.