### PR TITLE
[MB-1364] Remove message publish area in root topic

### DIFF
--- a/components/andes/org.wso2.carbon.andes.event.ui/src/main/resources/web/topics/topic_manage.jsp
+++ b/components/andes/org.wso2.carbon.andes.event.ui/src/main/resources/web/topics/topic_manage.jsp
@@ -283,48 +283,50 @@
 </div>
 <div style="clear:both">&nbsp;</div>
 
-<h3><fmt:message key="publish"/></h3>
-<table class="styledLeft">
-    <tr>
-        <td class="formRaw">
-            <table class="normal">
-                <tr>
-                    <td><fmt:message key="topic"/>
-                    </td>
-                    <td>
-                        <input class="longInput" type="text" readonly="true" name="topic"
-                               id="topic" value="<%=topic%>"/>
-                    </td>
+<%if (!topic.equals("/")) { %>
+    <h3><fmt:message key="publish"/></h3>
+    <table class="styledLeft">
+        <tr>
+            <td class="formRaw">
+                <table class="normal">
+                    <tr>
+                        <td><fmt:message key="topic"/>
+                        </td>
+                        <td>
+                            <input class="longInput" type="text" readonly="true" name="topic"
+                                   id="topic" value="<%=topic%>"/>
+                        </td>
 
-                </tr>
-                <tr>
-                    <td><fmt:message key="text.message"/></td>
-                    <td><textarea cols="50" rows="10" name="textMessage" id="textMessage"></textarea>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-    <tr>
+                    </tr>
+                    <tr>
+                        <td><fmt:message key="text.message"/></td>
+                        <td><textarea cols="50" rows="10" name="textMessage" id="textMessage"></textarea>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <tr>
 
-        <% try {
-            if(stub.checkCurrentUserHasPublishTopicPermission(topic)){ %>
-        <td>
-            <input type="button" onclick="invokeService()" value="<fmt:message key="publish"/>">
-        </td>
-        <% } else { %>
-        <td>
-            <input type="button" disabled onclick="invokeService()" value="<fmt:message key="publish"/>">
-        </td>
-        <% }
-        } catch (AndesEventAdminServiceEventAdminException e) { %>
-        <td>
-            <input type="button" disabled onclick="invokeService()" value="<fmt:message key="publish"/>">
-        </td>
-        <% } %>
+            <% try {
+                if(stub.checkCurrentUserHasPublishTopicPermission(topic)){ %>
+            <td>
+                <input type="button" onclick="invokeService()" value="<fmt:message key="publish"/>">
+            </td>
+            <% } else { %>
+            <td>
+                <input type="button" disabled onclick="invokeService()" value="<fmt:message key="publish"/>">
+            </td>
+            <% }
+            } catch (AndesEventAdminServiceEventAdminException e) { %>
+            <td>
+                <input type="button" disabled onclick="invokeService()" value="<fmt:message key="publish"/>">
+            </td>
+            <% } %>
 
-    </tr>
-</table>
+        </tr>
+    </table>
+<% } %>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Publishing messages in root topic should be avoided as root topic "/ " is not a topic and the user will be confused with the success popup shown for the published message.