### PR TITLE
[MB-1339] open ports as required when ssl enabled or disabled.

### DIFF
--- a/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
+++ b/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
@@ -469,7 +469,7 @@ public class QpidServiceComponent {
         boolean isServerStarted = false;
         int port;
 
-        if (qpidServiceImpl.getIfSSLOnly()) {
+        if (qpidServiceImpl.getMQTTSSLOnly()) {
             port = qpidServiceImpl.getMqttSSLPort();
         } else {
             port = qpidServiceImpl.getMqttPort();

--- a/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/service/QpidServiceImpl.java
+++ b/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/service/QpidServiceImpl.java
@@ -382,6 +382,17 @@ public class QpidServiceImpl implements QpidService {
     }
 
     /**
+     * Returns true if SSL port enabled and default port disabled.
+     *
+     * @return if only port enabled is SSL port
+     * @throws ConfigurationException
+     */
+    public boolean getMQTTSSLOnly() throws ConfigurationException {
+        return ApplicationRegistry.getInstance().getConfiguration().getMQTTSSLOnly();
+    }
+
+
+    /**
      * {@inheritDoc}
      */
     @Override


### PR DESCRIPTION
Open MQTT related ports as required when  SSL enabled/ disabled from broker configuration. 
This PR is dependent on https://github.com/wso2/andes/pull/382

https://wso2.org/jira/browse/MB-1339