### PR TITLE
[MB-1364] Remove message publish area in root topic

### DIFF
--- a/components/andes/org.wso2.carbon.andes.event.ui/src/main/resources/web/topics/topics.jsp
+++ b/components/andes/org.wso2.carbon.andes.event.ui/src/main/resources/web/topics/topics.jsp
@@ -137,6 +137,8 @@
 
 
                                         <%--View details--%>
+                                    <%if (!node.getTopicName().equals("/")) {%>
+
                                     <% try {
                                         if(stub.checkCurrentUserHasAddTopicPermission() || stub.checkCurrentUserHasDetailsTopicPermission()){ %>
                                     <a class="topicDetailsStyle"
@@ -146,6 +148,8 @@
                                     <% }
                                     } catch (AndesEventAdminServiceEventAdminException e) { %>
                                     <a class="topicDetailsStyle disabled-ahref">Details</a>
+                                    <% } %>
+
                                     <% } %>
 
 


### PR DESCRIPTION
Publishing messages in root topic should be avoided as root topic "/ " is not a topic and the user will be confused with the success popup shown for the published message.