### PR TITLE
MB-1441 issue fixed.

### DIFF
--- a/components/andes/org.wso2.carbon.andes.commons/src/main/java/org/wso2/carbon/andes/commons/registry/RegistryClient.java
+++ b/components/andes/org.wso2.carbon.andes.commons/src/main/java/org/wso2/carbon/andes/commons/registry/RegistryClient.java
@@ -298,7 +298,8 @@ public class RegistryClient {
             );
 
             // Get subscriptions
-            String subscriptionsID = CommonsUtil.getSubscriptionsID(topic);
+            String tenantBasedTopicName = getTenantBasedTopicName(topic);
+            String subscriptionsID = CommonsUtil.getSubscriptionsID(tenantBasedTopicName);
             if (registry.resourceExists(subscriptionsID)) {
                 Collection subscriptionCollection = (Collection) registry.get(subscriptionsID);
                 subscriptionDetailsArray =

--- a/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/QueueManagerServiceImpl.java
+++ b/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/QueueManagerServiceImpl.java
@@ -110,7 +110,15 @@ public class QueueManagerServiceImpl implements QueueManagerService {
                                         .getTenantId());
 
                 String queueID = CommonsUtil.getQueueID(queueName);
-                authorizePermissionsToLoggedInUser(tenantBasedQueueName, queueID, userRealm);
+                String loggedInUser = CarbonContext.getThreadLocalCarbonContext().getUsername();
+
+                //Internal role create by topic name and grant subscribe and publish permission to it
+                //By this way we restricted permission to user who create topic and allow subscribe and publish
+                //We avoid creating internal role if Admin user creating a queue
+                //Admin has to give permission to other roles to subscribe and publish if necessary
+                if (!Utils.isAdmin(loggedInUser)) {
+                    authorizePermissionsToLoggedInUser(tenantBasedQueueName, queueID, userRealm);
+                }
 
             } else {
                 // TODO : Can we use error code for cleaner error handling ? this will hard bind to

--- a/components/andes/org.wso2.carbon.andes.event.core/src/main/java/org/wso2/carbon/andes/event/core/internal/subscription/registry/TopicManagerServiceImpl.java
+++ b/components/andes/org.wso2.carbon.andes.event.core/src/main/java/org/wso2/carbon/andes/event/core/internal/subscription/registry/TopicManagerServiceImpl.java
@@ -177,8 +177,11 @@ public class TopicManagerServiceImpl implements TopicManagerService {
 
                 //Internal role create by topic name and grant subscribe and publish permission to it
                 //By this way we restricted permission to user who create topic and allow subscribe and publish
+                //We avoid creating internal role if Admin user creating a topic
                 //Admin has to give permission to other roles to subscribe and publish if necessary
-                authorizePermissionsToLoggedInUser(loggedInUser, topicName, resourcePath, userRealm);
+                if (!JavaUtil.isAdmin(loggedInUser)) {
+                    authorizePermissionsToLoggedInUser(loggedInUser, topicName, resourcePath, userRealm);
+                }
             }
         } catch (RegistryException e) {
             throw new EventBrokerException("Cannot access the config registry", e);


### PR DESCRIPTION
- Admin user allow to proceed with any operation. But issue mentioned in jira has problem with super tenant admin user created topic/durable topic could access to tenant admin user. This has avoid by granting permission for that particular topic/durable topic to admin user role of particular tenant.
- Previously we create internal role when create queue/topic by admin user. This has avoid with this because admin user by default allow to proceed with any operation.