### PR TITLE
MB-1386, MB-1391, MB-1427, MB-1455, MB-1470

### DIFF
--- a/components/andes/org.wso2.carbon.andes.commons/pom.xml
+++ b/components/andes/org.wso2.carbon.andes.commons/pom.xml
@@ -39,6 +39,11 @@
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.andes.wso2</groupId>
+            <artifactId>andes</artifactId>
+            <version>${andes.dependency.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/andes/org.wso2.carbon.andes.commons/src/main/java/org/wso2/carbon/andes/commons/registry/RegistryClient.java
+++ b/components/andes/org.wso2.carbon.andes.commons/src/main/java/org/wso2/carbon/andes/commons/registry/RegistryClient.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.andes.commons.registry;
 import org.apache.axis2.databinding.utils.ConverterUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesConstants;
 import org.wso2.carbon.andes.commons.CommonsUtil;
 import org.wso2.carbon.andes.commons.QueueDetails;
 import org.wso2.carbon.andes.commons.SubscriptionDetails;
@@ -49,6 +50,7 @@ public class RegistryClient {
     private static final String CREATED_FROM_AMQP = "amqp";
     private static final String USER_COUNT = "userCount";
     private static final Log log = LogFactory.getLog(RegistryClient.class);
+
     /**
      * Create an entry for a queue in the Registry
      *
@@ -58,8 +60,12 @@ public class RegistryClient {
      */
     public static void createQueue(String queueName, String owner)
             throws RegistryClientException {
-        try {
 
+        if (log.isDebugEnabled()) {
+            log.debug("Saving queue name \"" + queueName + "\" in Registry");
+        }
+
+        try {
             RegistryService registryService = CommonsDataHolder.getInstance().getRegistryService();
             UserRegistry registry = registryService.getGovernanceSystemRegistry(
                     PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId() <= 0 ?
@@ -197,9 +203,13 @@ public class RegistryClient {
     public static void createSubscription(
             String topic, String subscriptionName, String owner)
             throws RegistryClientException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Saving topic name: \"" + topic
+                    + "\" in registry, and subscription name for this topic is: " + subscriptionName);
+        }
+
         try {
-
-
             RegistryService registryService = CommonsDataHolder.getInstance().getRegistryService();
             UserRegistry registry = registryService.getGovernanceSystemRegistry(
                     CarbonContext.getThreadLocalCarbonContext().getTenantId() <= 0 ?
@@ -234,11 +244,12 @@ public class RegistryClient {
      * @return tenant based topic name
      */
     public static String getTenantBasedTopicName(String topicName) {
+
         String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         String tenantBasedTopicName = topicName;
         if (tenantDomain != null && (!tenantDomain.equals(
                 org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))) {
-            String formattedTenantDomain = tenantDomain + "/";
+            String formattedTenantDomain = tenantDomain + AndesConstants.TENANT_SEPARATOR;
             if (topicName.contains(formattedTenantDomain)) {
                 tenantBasedTopicName = topicName.substring(formattedTenantDomain.length());
             }
@@ -344,4 +355,5 @@ public class RegistryClient {
             throw new RegistryClientException(e);
         }
     }
+
 }

--- a/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/internal/util/Utils.java
+++ b/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/internal/util/Utils.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang.StringUtils;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
 import org.wso2.andes.configuration.modules.JKSStore;
+import org.wso2.andes.kernel.AndesConstants;
 import org.wso2.carbon.andes.core.QueueManagerException;
 import org.wso2.carbon.andes.core.internal.ds.QueueManagerServiceValueHolder;
 import org.wso2.carbon.andes.core.types.Queue;
@@ -115,7 +116,7 @@ public class Utils {
         if (tenantDomain != null && (!queueName.contains(tenantDomain)) &&
             (!tenantDomain.equals(org.wso2.carbon.base.MultitenantConstants.
                                           SUPER_TENANT_DOMAIN_NAME))) {
-            queueName = tenantDomain + "/" + queueName;
+            queueName = tenantDomain + AndesConstants.TENANT_SEPARATOR + queueName;
         }
         return queueName;
     }
@@ -191,9 +192,9 @@ public class Utils {
             }
         }
         //for super tenant load all queues not specific to a domain. That means queues created by external
-        //JMS clients are visible, and those names should not have "/" in their queue names
+        //JMS clients are visible, and those names should not have the tenant separator "/" in their queue names
         else {
-            if (!queue.getQueueName().contains("/")) {
+            if (!queue.getQueueName().contains(AndesConstants.TENANT_SEPARATOR)) {
                 return true;
             }
         }
@@ -219,7 +220,7 @@ public class Utils {
                 //for queues filter by queue name queueName=<tenantDomain>/queueName
                 //for temp topics filter by topic name topicName=<tenantDomain>/topicName
                 //for durable topic subs filter by topic name topicName=<tenantDomain>/topicName
-                if (subscription.getSubscribedQueueOrTopicName().startsWith(domainName + "/")) {
+                if (subscription.getSubscribedQueueOrTopicName().startsWith(domainName + AndesConstants.TENANT_SEPARATOR)) {
                     tenantFilteredSubscriptions.add(subscription);
                 }
             }
@@ -227,7 +228,7 @@ public class Utils {
         } else if (domainName != null && CarbonContext.getThreadLocalCarbonContext().getTenantDomain().
                 equals(org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
             for (Subscription subscription : allSubscriptions) {
-                if (!subscription.getSubscribedQueueOrTopicName().contains("/")) {
+                if (!subscription.getSubscribedQueueOrTopicName().contains(AndesConstants.TENANT_SEPARATOR)) {
                     tenantFilteredSubscriptions.add(subscription);
                 }
             }
@@ -530,16 +531,16 @@ public class Utils {
         boolean isOwnDomain = false;
         if (tenantDomain != null) {
             if ((routingKey.length() >= tenantDomain.length() + 1) && routingKey.substring(0,
-                    tenantDomain.length() + 1).equals(tenantDomain + "/")) {
+                    tenantDomain.length() + 1).equals(tenantDomain + AndesConstants.TENANT_SEPARATOR)) {
                 isOwnDomain = true;
             } else if (tenantDomain.equalsIgnoreCase("carbon.super")) {
-                if (!routingKey.contains("/")) {
+                if (!routingKey.contains(AndesConstants.TENANT_SEPARATOR)) {
                     isOwnDomain = true;
                 }
             }
         } else {
             // tenantDomain is null,this implies this is a normal user.
-            if (!routingKey.contains("/")) {
+            if (!routingKey.contains(AndesConstants.TENANT_SEPARATOR)) {
                 isOwnDomain = true;
             }
         }

--- a/components/andes/org.wso2.carbon.andes.event.core/pom.xml
+++ b/components/andes/org.wso2.carbon.andes.event.core/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.wso2.andes.wso2</groupId>
+            <artifactId>andes</artifactId>
+            <version>${andes.dependency.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.securevault</groupId>
             <artifactId>org.wso2.securevault</artifactId>
         </dependency>

--- a/components/andes/org.wso2.carbon.andes.event.core/src/main/java/org/wso2/carbon/andes/event/core/internal/subscription/registry/TopicManagerServiceImpl.java
+++ b/components/andes/org.wso2.carbon.andes.event.core/src/main/java/org/wso2/carbon/andes/event/core/internal/subscription/registry/TopicManagerServiceImpl.java
@@ -16,10 +16,10 @@
 
 package org.wso2.carbon.andes.event.core.internal.subscription.registry;
 
-import org.apache.axis2.databinding.utils.ConverterUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.andes.server.NameValidationUtils;
 import org.wso2.carbon.andes.event.core.TopicManagerService;
 import org.wso2.carbon.andes.event.core.TopicNode;
 import org.wso2.carbon.andes.event.core.TopicRolePermission;
@@ -38,9 +38,7 @@ import org.wso2.carbon.user.api.AuthorizationManager;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
-import org.wso2.carbon.user.core.authorization.TreeNode;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
-import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.*;
@@ -152,15 +150,17 @@ public class TopicManagerServiceImpl implements TopicManagerService {
     }
 
     /**
+     * Adding topic, when creating topics from the user interface
+     *
      * {@inheritDoc}
      */
     @Override
     public void addTopic(String topicName) throws EventBrokerException {
-        if (!validateTopicName(topicName)) {
-            throw new EventBrokerException("Topic name " + topicName + " is not a valid topic name. " +
-                                           "Only alphanumeric characters, hyphens (-), stars(*)," +
-                                           " hash(#) ,dot(.),question mark(?)" +
-                                           " and underscores (_) are allowed.");
+        //Prevent creating topics, if topic name is not valid
+        if (!NameValidationUtils.isValidUITopicName(topicName)) {
+            throw new EventBrokerException("Topic name " + topicName + " is not a valid topic name. Only alphanumeric"
+                    + " characters, stars(*), hash(#) and dots(.) are allowed. Dot can only use in the middle of the"
+                    + " name, as a delimiter and hash can only use at the end of the name. ");
         }
 
         String loggedInUser = CarbonContext.getThreadLocalCarbonContext().getUsername();
@@ -517,16 +517,6 @@ public class TopicManagerServiceImpl implements TopicManagerService {
 
         topicName = topicName + EventBrokerConstants.EB_CONF_WS_SUBSCRIPTION_COLLECTION_NAME;
         return topicName;
-    }
-
-    /**
-     * Validates a topic name. Checks for invalid characters
-     *
-     * @param topicName topic name
-     * @return true if topic name is valid, false otherwise.
-     */
-    private boolean validateTopicName(String topicName) {
-        return Pattern.matches("[[a-zA-Z]+[^(\\x00-\\x80)]+[0-9_\\-/#*:.?&\\s()]+]+", topicName);
     }
 
     /**

--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/js/treecontrol.js
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/js/treecontrol.js
@@ -1,3 +1,6 @@
+/**
+ * Adding queues, when creating queues from the user interface
+ */
 function addQueue(createdFrom) {
     var topic = document.getElementById("queue");
 
@@ -6,7 +9,7 @@ function addQueue(createdFrom) {
     if (topic.value == "") {
         error = "Queue name cannot be empty.\n";
     } else if (!isValidQueueName(topic.value)) {
-        error = "Queue name cannot contain any of following symbols ~!@#;%^*()+={}|\<>\"',\n";
+        error = "Queue name cannot contain any of following symbols ~!@#;%^*()+={}|\<>\"'/, and space \n";
     } else if (isContainTmpPrefix(topic.value)) {
         error = "Queue name cannot start with tmp_ prefix.\n";
     }
@@ -17,8 +20,11 @@ function addQueue(createdFrom) {
     addQueueAndAssignPermissions(topic.value, createdFrom);
 }
 
+/**
+ * Validating queue names, when creating queues from user interface
+ */
 function isValidQueueName(queueName){
-    return !/[~!@#;%^*()+={}|\<>"',]/g.test(queueName);
+    return !/[~!@#;%^*()+={}|\<>"'/,\s]/g.test(queueName);
 }
 
 function isContainTmpPrefix(queueName) {


### PR DESCRIPTION
Changes related to queue/topic names:

MB-1386 : Queue/Topic names should be trimmed before saving
MB-1391 : If a message is published from UI to a topic with a name which has a space in-between the message is not routed to the subscribers
MB-1427 : Prevent topic creation which has two full stops subsequently e.g - Sports..
MB-1455 : Queue names which has the " / " is not shown in UI
MB-1470 : "Cannot access the config registry" error message is displayed when trying to create a topic with *, # characters 

This fix validates queue/topic names, when creating queues/topics from UI.

As said in the AMQP specification, this PR allows only alphanumeric, '.', '*' and '#' characters when creating topics. Also, prohibited space and the tenant separator '/', when creating queues. 

Please merge with: https://github.com/wso2/andes/pull/442