### PR TITLE
[MB-1469] [Tenant] DLC page not accessible in clustered environment

### DIFF
--- a/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/listeners/MessageBrokerTenantManagementListener.java
+++ b/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/listeners/MessageBrokerTenantManagementListener.java
@@ -1,7 +1,6 @@
 package org.wso2.carbon.andes.listeners;
 
 import org.apache.log4j.Logger;
-import org.wso2.andes.kernel.AndesContext;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.server.queue.DLCQueueUtils;
 import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
@@ -25,10 +24,7 @@ public class MessageBrokerTenantManagementListener implements TenantMgtListener 
         String tenantOwner = tenantInfoBean.getAdmin();
 
         try {
-            // Create DLC if not clustered or else Create DLC if this is the coordinator
-            if (!AndesContext.getInstance().isClusteringEnabled() || AndesContext.getInstance().getClusterAgent().isCoordinator()) {
-                DLCQueueUtils.createDLCQueue(tenantName, tenantOwner);
-            }
+            DLCQueueUtils.createDLCQueue(tenantName, tenantOwner);
         } catch (AndesException e) {
             logger.error("Error creating DLC Queue for tenant", e);
         }


### PR DESCRIPTION
Since the tenant create notification is only received to a single
node, we can initialize the DLC without checking if coordinator.

https://wso2.org/jira/browse/MB-1469