### PR TITLE
Permission corrected for the operation to get queue

### DIFF
--- a/components/andes/org.wso2.carbon.andes.admin/src/main/resources/META-INF/services.xml
+++ b/components/andes/org.wso2.carbon.andes.admin/src/main/resources/META-INF/services.xml
@@ -42,7 +42,7 @@
             <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/queue/browse,/permission/admin/manage/topic/details,/permission/admin/manage/dlc/browse,/permission/admin/manage/dlc/delete,/permission/admin/manage/dlc/restore,/permission/admin/manage/dlc/reroute</parameter>
         </operation>
         <operation name="getQueueByName">
-            <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/queue</parameter>
+            <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/queue/add,/permission/admin/manage/queue/browse,/permission/admin/manage/queue/purge,/permission/admin/manage/queue/delete</parameter>
         </operation>
         <operation name="getDLCQueue">
             <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/dlc/browse,/permission/admin/manage/dlc/delete,/permission/admin/manage/dlc/restore,/permission/admin/manage/dlc/reroute</parameter>


### PR DESCRIPTION
The operation getQueueByName was only given parent permission. Corrected that to have all 
/permission/admin/manage/queue/add
/permission/admin/manage/queue/browse
/permission/admin/manage/queue/purge
/permission/admin/manage/queue/delete