### PR TITLE
removed unnecessary columns on DLC page

### DIFF
--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_messages_list.jsp
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_messages_list.jsp
@@ -270,8 +270,6 @@
                                onClick="toggleCheck(this)"/></th>
                     <th><fmt:message key="message.contenttype"/></th>
                     <th><fmt:message key="message.messageId"/></th>
-                    <th><fmt:message key="message.redelivered"/></th>
-                    <th><fmt:message key="message.deliverymode"/></th>
                     <th><fmt:message key="message.timestamp"/></th>
                     <th><fmt:message key="message.destination"/></th>
                     <th><fmt:message key="message.properties"/></th>
@@ -298,10 +296,6 @@
                              alt=""/>&nbsp;&nbsp;<%= contentType%>
                     </td>
                     <td><%= queueMessage.getJMSMessageId()%>
-                    </td>
-                    <td><%= queueMessage.getJMSReDelivered()%>
-                    </td>
-                    <td><%= queueMessage.getJMSDeliveredMode()%>
                     </td>
                     <td><%= queueMessage.getJMSTimeStamp()%>
                     </td>


### PR DESCRIPTION
Fixing https://wso2.org/jira/browse/MB-1576

Now DLC queue does not display "redelivered" and "deliverymode" pages.