### PR TITLE
[MB-1722] DM_DEFAULT_ENCODING Fix undefined character encoding issue.

### DIFF
--- a/components/andes/src/main/java/org/wso2/carbon/andes/core/AndesEncodingUtil.java
+++ b/components/andes/src/main/java/org/wso2/carbon/andes/core/AndesEncodingUtil.java
@@ -80,7 +80,7 @@ public class AndesEncodingUtil {
         int length = buffer.getInt();
         byte[] byteArray = new byte[length];
         buffer.get(byteArray);
-        return new String(byteArray);
+        return new String(byteArray, StandardCharsets.UTF_8);
     }
 
     /**

--- a/components/andes/src/main/java/org/wso2/carbon/andes/core/AndesUtils.java
+++ b/components/andes/src/main/java/org/wso2/carbon/andes/core/AndesUtils.java
@@ -27,9 +27,11 @@ import org.wso2.carbon.andes.core.subscription.LocalSubscription;
 import org.wso2.carbon.andes.core.subscription.OutboundSubscription;
 
 import java.io.BufferedWriter;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -110,7 +112,9 @@ public class AndesUtils {
     public static void writeToFile(String whatToWrite, String filePath) {
         try {
             if (printWriterGlobal == null) {
-                BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(filePath));
+                OutputStreamWriter streamWriter = new OutputStreamWriter(new FileOutputStream(filePath),
+                                                                         StandardCharsets.UTF_8);
+                BufferedWriter bufferedWriter = new BufferedWriter(streamWriter);
                 printWriterGlobal = new PrintWriter(bufferedWriter);
             }
 

--- a/components/andes/src/main/java/org/wso2/carbon/andes/core/internal/slot/SlotDeliveryWorker.java
+++ b/components/andes/src/main/java/org/wso2/carbon/andes/core/internal/slot/SlotDeliveryWorker.java
@@ -37,8 +37,10 @@ import org.wso2.carbon.andes.core.store.StoreHealthListener;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -505,7 +507,8 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener, N
      */
     public void dumpAllSlotInformationToFile(File fileToWrite) throws AndesException {
         try {
-            FileWriter information = new FileWriter(fileToWrite);
+            OutputStreamWriter information = new OutputStreamWriter(new FileOutputStream(fileToWrite),
+                                                                    StandardCharsets.UTF_8);
             for (Map.Entry<String, Map<String, Slot>> storageQueueToSlotEntry : storageQueueToSlotTracker.entrySet()) {
                 String storageQueue = storageQueueToSlotEntry.getKey();
                 Map<String, Slot> slotIdToSlotMap = storageQueueToSlotEntry.getValue();


### PR DESCRIPTION
Define character encoding to UTF-8. Otherwise, it will default to system default encoding which is not recommended. 
This issue was reported by findbugs under DM_DEFAULT_ENCODING category.