### PR TITLE
MB-1783 issue fixed.

### DIFF
--- a/components/andes/org.wso2.carbon.andes.authorization/src/main/java/org/wso2/carbon/andes/authorization/andes/AndesAuthorizationHandler.java
+++ b/components/andes/org.wso2.carbon.andes.authorization/src/main/java/org/wso2/carbon/andes/authorization/andes/AndesAuthorizationHandler.java
@@ -869,11 +869,17 @@ public class AndesAuthorizationHandler {
                         isOwnDomain = true;
                     }
                 } else if (isTopicSubscriberQueue(routingKey) &&
-                        !Boolean.valueOf(properties.get(ObjectProperties.Property.DURABLE))) { //allow permission to non durable topics to create temporary queue i.e. tmp_127_0_0_1_46981_1
+                        !Boolean.valueOf(properties.get(ObjectProperties.Property.DURABLE))) {
+                    //allow permission to non durable topics to create temporary queue i.e. tmp_127_0_0_1_46981_1
                     isOwnDomain = true;
                 } else if (Boolean.valueOf(properties.get(ObjectProperties.Property.DURABLE)) &&
-                        Boolean.valueOf(properties.get(ObjectProperties.Property.EXCLUSIVE))) { //allow permission to durable topics to create internal queue i.e. carbon:subId
-                    isOwnDomain = true;
+                        Boolean.valueOf(properties.get(ObjectProperties.Property.EXCLUSIVE))) {
+                    //only sub tenant call comes into this block, super tenant call would evaluate in above
+                    //allow permission only if subscription id prefix with tenant domain
+                    //i.e. {tenant_domain}/{subscription_id}
+                    if (routingKey.substring(routingKey.lastIndexOf(":") + 1).startsWith(tenantDomain)) {
+                        isOwnDomain = true;
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
- Public JIRA URL https://wso2.org/jira/browse/MB-1783. The fix is to compel subscription id pattern as {tenant_domain}/{subscription_id} when adding durable subscription to sub-tenant. Otherwise, connection will end up in permission denied the exception.