### PR TITLE
Implementing dynamic discovery

### DIFF
--- a/components/andes/org.wso2.carbon.andes.cluster.mgt/src/main/java/org/wso2/carbon/andes/cluster/mgt/ClusterManagerService.java
+++ b/components/andes/org.wso2.carbon.andes.cluster.mgt/src/main/java/org/wso2/carbon/andes/cluster/mgt/ClusterManagerService.java
@@ -77,4 +77,16 @@ public class ClusterManagerService extends AbstractAdmin {
         ClusterManagementBeans clusterManagementBeans = new ClusterManagementBeans();
         return clusterManagementBeans.getStoreHealth();
     }
+
+    /**
+     * Gets the live node ip and port details in cluster
+     * @return String node ip and port eg- 127.0.0.1:5672
+     * @throws ClusterMgtException
+     */
+    public String getBrokerInformation() throws ClusterMgtException {
+
+        ClusterManagementBeans clusterManagementBeans = new ClusterManagementBeans();
+        return clusterManagementBeans.getBrokerInformation();
+
+    }
 }

--- a/components/andes/org.wso2.carbon.andes.cluster.mgt/src/main/java/org/wso2/carbon/andes/cluster/mgt/internal/ClusterMgtConstants.java
+++ b/components/andes/org.wso2.carbon.andes.cluster.mgt/src/main/java/org/wso2/carbon/andes/cluster/mgt/internal/ClusterMgtConstants.java
@@ -46,4 +46,9 @@ public class ClusterMgtConstants {
      * Attribute name for 'StoreHealth'
      */
     public static final String STORE_HEALTH = "StoreHealth";
+
+    /**
+     * Attribute name for 'AllLiveNodeAddresses'
+     */
+    public static final String BROKER_DETAIL = "BrokerDetail";
 }

--- a/components/andes/org.wso2.carbon.andes.cluster.mgt/src/main/java/org/wso2/carbon/andes/cluster/mgt/internal/managementBeans/ClusterManagementBeans.java
+++ b/components/andes/org.wso2.carbon.andes.cluster.mgt/src/main/java/org/wso2/carbon/andes/cluster/mgt/internal/managementBeans/ClusterManagementBeans.java
@@ -49,7 +49,7 @@ public class ClusterManagementBeans {
         try {
             ObjectName objectName =
                     new ObjectName("org.wso2.andes:type=ClusterManagementInformation," +
-                                   "name=ClusterManagementInformation");
+                            "name=ClusterManagementInformation");
             Object result = mBeanServer.getAttribute(objectName, ClusterMgtConstants.IS_CLUSTERING_ENABLED);
 
             if (result != null) {
@@ -82,7 +82,7 @@ public class ClusterManagementBeans {
         try {
             ObjectName objectName =
                     new ObjectName("org.wso2.andes:type=ClusterManagementInformation," +
-                                   "name=ClusterManagementInformation");
+                            "name=ClusterManagementInformation");
             Object result = mBeanServer.getAttribute(objectName, ClusterMgtConstants.MY_NODE_ID);
 
             if (result != null) {
@@ -115,7 +115,7 @@ public class ClusterManagementBeans {
         try {
             ObjectName objectName =
                     new ObjectName("org.wso2.andes:type=ClusterManagementInformation," +
-                                   "name=ClusterManagementInformation");
+                            "name=ClusterManagementInformation");
             Object result = mBeanServer.getAttribute(objectName, ClusterMgtConstants.COORDINATOR_NODE_ADDRESS);
             if (result != null) {
                 coordinatorNodeAddress = (String) result;
@@ -148,7 +148,7 @@ public class ClusterManagementBeans {
 
             ObjectName objectName =
                     new ObjectName("org.wso2.andes:type=ClusterManagementInformation," +
-                                   "name=ClusterManagementInformation");
+                            "name=ClusterManagementInformation");
             Object result = mBeanServer.getAttribute(objectName, ClusterMgtConstants.ALL_CLUSTER_NODE_ADDRESSES);
 
             if (result != null) {
@@ -181,7 +181,7 @@ public class ClusterManagementBeans {
         try {
             ObjectName objectName =
                     new ObjectName("org.wso2.andes:type=ClusterManagementInformation," +
-                                   "name=ClusterManagementInformation");
+                            "name=ClusterManagementInformation");
             Object result = mBeanServer.getAttribute(objectName, ClusterMgtConstants.STORE_HEALTH);
             if (result != null) {
                 storeHealth = (Boolean) result;
@@ -200,4 +200,35 @@ public class ClusterManagementBeans {
             throw new ClusterMgtException("Cannot get message store health.", e);
         }
     }
+
+    /**
+     * Got the live nodes details on cluster
+     *
+     * @return String node IPs and Ports
+     * @throws ClusterMgtException
+     */
+
+    public String getBrokerInformation() throws ClusterMgtException {
+        String brokerInformation = "";
+        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        try {
+
+            ObjectName objectName =
+                    new ObjectName("org.wso2.andes:type=ClusterManagementInformation,"
+                            + "name=ClusterManagementInformation");
+            Object result = mBeanServer.getAttribute(objectName, ClusterMgtConstants.BROKER_DETAIL);
+
+            if (result != null) {
+                brokerInformation = (String) result;
+            }
+
+
+        } catch (MalformedObjectNameException | ReflectionException | MBeanException | AttributeNotFoundException | InstanceNotFoundException e) {
+            throw new ClusterMgtException("Cannot get live node addresses", e);
+        }
+
+        return brokerInformation;
+    }
+
+
 }

--- a/components/andes/org.wso2.carbon.andes.cluster.mgt/src/main/resources/META-INF/component.xml
+++ b/components/andes/org.wso2.carbon.andes.cluster.mgt/src/main/resources/META-INF/component.xml
@@ -25,5 +25,9 @@
             <DisplayName>Nodes</DisplayName>
             <ResourceId>/permission/admin/manage/cluster/list</ResourceId>
         </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Dynamic Discovery</DisplayName>
+            <ResourceId>/permission/admin/manage/brokerDiscovery</ResourceId>
+        </ManagementPermission>
     </ManagementPermissions>
 </component>

--- a/components/andes/org.wso2.carbon.andes.cluster.mgt/src/main/resources/META-INF/services.xml
+++ b/components/andes/org.wso2.carbon.andes.cluster.mgt/src/main/resources/META-INF/services.xml
@@ -32,10 +32,28 @@
                              class="org.apache.axis2.rpc.receivers.RPCMessageReceiver"/>
         </messageReceivers>
         <parameter name="ServiceClass">org.wso2.carbon.andes.cluster.mgt.ClusterManagerService</parameter>
-    </service>
 
-    <parameter name="adminService" locked="true">true</parameter>
-    <parameter name="hiddenService" locked="true">true</parameter>
-    <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/cluster/list,/permission/admin/manage/subscriptions/queue-browse,/permission/admin/manage/subscriptions/topic-browse</parameter>
-    
+        <parameter name="adminService" locked="true">true</parameter>
+        <parameter name="hiddenService" locked="true">true</parameter>
+
+        <operation name="getAllClusterNodeAddresses">
+            <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/cluster/list,/permission/admin/manage/subscriptions/queue-browse,/permission/admin/manage/subscriptions/topic-browse</parameter>
+        </operation>
+
+        <operation name="isClusteringEnabled">
+            <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/cluster/list,/permission/admin/manage/subscriptions/queue-browse,/permission/admin/manage/subscriptions/topic-browse</parameter>
+        </operation>
+
+        <operation name="getMyNodeID">
+            <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/cluster/list,/permission/admin/manage/subscriptions/queue-browse,/permission/admin/manage/subscriptions/topic-browse</parameter>
+        </operation>
+
+        <operation name="getStoreHealth">
+            <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/cluster/list,/permission/admin/manage/subscriptions/queue-browse,/permission/admin/manage/subscriptions/topic-browse</parameter>
+        </operation>
+
+        <operation name="getBrokerInformation">
+            <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/brokerDiscovery</parameter>
+        </operation>
+    </service>
 </serviceGroup>

--- a/components/andes/org.wso2.carbon.andes.dynamic-discovery/pom.xml
+++ b/components/andes/org.wso2.carbon.andes.dynamic-discovery/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>andes</artifactId>
+        <groupId>org.wso2.carbon.messaging</groupId>
+        <version>3.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.carbon.andes.dynamic-discovery</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Component - Andes DynamicDiscovery</name>
+    <description>Dynamic Discovery</description>
+    <url>http://wso2.org</url>
+
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.andes.wso2</groupId>
+            <artifactId>andes</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.messaging</groupId>
+            <artifactId>org.wso2.carbon.andes</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <version>1.7.4</version>
+                <executions>
+                    <execution>
+                        <id>generate-scr-descriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.wso2.carbon.andes.discovery.*
+                        </Export-Package>
+                        <Import-Package>
+                            org.wso2.andes.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/components/andes/org.wso2.carbon.andes.dynamic-discovery/src/main/java/org/wso2/carbon/andes/discovery/DiscoveryActivator.java
+++ b/components/andes/org.wso2.carbon.andes.dynamic-discovery/src/main/java/org/wso2/carbon/andes/discovery/DiscoveryActivator.java
@@ -1,0 +1,54 @@
+/*
+* Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.andes.discovery;
+
+
+import org.osgi.framework.BundleException;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.andes.server.cluster.IpAddressRetriever;
+
+
+/**
+ * @scr.component name="org.wso2.carbon.andes.discovery.DiscoveryActivator"
+ * immediate="true"
+ */
+public class DiscoveryActivator {
+
+    protected final Logger logger = LoggerFactory.getLogger(DiscoveryActivator.class);
+
+    protected void activate(ComponentContext ctx) {
+
+        LocalCluster localCluster = new LocalCluster();
+        ctx.getBundleContext().registerService(IpAddressRetriever.class.getName(),localCluster,null);
+
+    }
+
+    /**
+     * Unregister OSGi services that were registered at the time of activation
+     *
+     * @param ctx component context
+     * @throws BundleException
+     */
+    protected void deactivate(ComponentContext ctx) throws BundleException {
+        ctx.getBundleContext().getBundle().stop();
+
+    }
+
+}

--- a/components/andes/org.wso2.carbon.andes.dynamic-discovery/src/main/java/org/wso2/carbon/andes/discovery/LocalCluster.java
+++ b/components/andes/org.wso2.carbon.andes.dynamic-discovery/src/main/java/org/wso2/carbon/andes/discovery/LocalCluster.java
@@ -1,0 +1,127 @@
+/*
+* Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.andes.discovery;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.andes.server.cluster.IpAddressRetriever;
+import org.wso2.andes.server.cluster.MultipleAddressDetails;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+public class LocalCluster implements IpAddressRetriever {
+
+        /**
+         * IP address of all the interfaces in node.
+         */
+
+        private List<MultipleAddressDetails> multipleAddressDetailsList = new ArrayList<>();
+        /**
+         * IP address of one of interface.
+         */
+        private String localIpAddress = null;
+
+        /**
+         * Class logger.
+         */
+        protected final Logger logger = LoggerFactory.getLogger(LocalCluster.class);
+
+        /**
+         * Get the interface bind ip address.
+         */
+        private void lookupLocalAddress() {
+            try {
+            /* This class represents a Network Interface made up of a name,
+             and a list of IP addresses assigned to this interface.
+             */
+                Enumeration<NetworkInterface> networkInterfaces = NetworkInterface
+                        .getNetworkInterfaces();
+
+                while (networkInterfaces.hasMoreElements()) {
+                    NetworkInterface networkInterface = networkInterfaces
+                            .nextElement();
+                /* Check for mac address */
+                    byte[] hardwareAddress = networkInterface.getHardwareAddress();
+                    if ((hardwareAddress == null) || (hardwareAddress.length == 0)) {
+                        continue;
+                    }
+                    Set<InetAddress> subAddresses = new HashSet<InetAddress>();
+                    Enumeration<NetworkInterface> subInterfaces = networkInterface.getSubInterfaces();
+                    while (subInterfaces.hasMoreElements()) {
+                        NetworkInterface subInterface = subInterfaces.nextElement();
+                        for (InterfaceAddress interfaceAddress : subInterface
+                                .getInterfaceAddresses()) {
+                            subAddresses.add(interfaceAddress.getAddress());
+                        }
+                    }
+                    List<InterfaceAddress> interfaceAddresses = networkInterface
+                            .getInterfaceAddresses();
+                    for (InterfaceAddress interfaceAddress : interfaceAddresses) {
+                        InetAddress address = interfaceAddress.getAddress();
+                        if (address.isLoopbackAddress()) {
+                            continue;
+                        }
+                   /* if (subAddresses.contains(address)) {
+                        continue;
+                    }*/
+
+                        if (address instanceof Inet4Address) {
+
+                            MultipleAddressDetails multipleAddressDetails = new MultipleAddressDetails
+                                    (networkInterface.getDisplayName(),address.getHostAddress());
+                            multipleAddressDetailsList.add(multipleAddressDetails);
+
+                        }
+                    }
+                }
+            } catch (SocketException e) {
+                logger.error("Error occurred while retrieving IP address",e);
+            }
+            if (localIpAddress == null) {
+                try {
+                    localIpAddress = InetAddress.getLocalHost().getHostAddress();
+                } catch (UnknownHostException e) {
+                    localIpAddress = "127.0.0.1";
+                }
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public List<MultipleAddressDetails> getLocalAddress() {
+
+                 lookupLocalAddress();
+                //return localIpAddress;
+                return multipleAddressDetailsList;
+
+        }
+
+
+}

--- a/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
+++ b/components/andes/org.wso2.carbon.andes/src/main/java/org/wso2/carbon/andes/internal/QpidServiceComponent.java
@@ -6,7 +6,7 @@
  *   in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0p
  *
  *   Unless required by applicable law or agreed to in writing,
  *   software distributed under the License is distributed on an
@@ -32,6 +32,7 @@ import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesKernelBoot;
 import org.wso2.andes.server.BrokerOptions;
 import org.wso2.andes.server.Main;
+import org.wso2.andes.server.cluster.IpAddressRetriever;
 import org.wso2.andes.server.cluster.coordination.hazelcast.HazelcastAgent;
 import org.wso2.andes.server.registry.ApplicationRegistry;
 import org.wso2.andes.wso2.service.QpidNotificationService;
@@ -52,15 +53,15 @@ import org.wso2.carbon.server.admin.common.IServerAdmin;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.util.Set;
 import java.util.Stack;
-import javax.management.MBeanServer;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
 
 /**
  * @scr.component name="org.wso2.carbon.andes.internal.QpidServiceComponent"
@@ -105,6 +106,12 @@ import javax.management.ObjectName;
  * cardinality="1..1" policy="dynamic"
  * bind="setIServerAdmin"
  * unbind="unsetIServerAdmin"
+ * @scr.reference name="org.wso2.andes.server.cluster.IpAddressRetriever"
+ * interface="org.wso2.andes.server.cluster.IpAddressRetriever"
+ * cardinality="1..1"
+ * policy="dynamic"
+ * bind="setAddressRetriever"
+ * unbind="unsetAddressRetriever"
  */
 public class QpidServiceComponent {
 
@@ -295,6 +302,20 @@ public class QpidServiceComponent {
         QpidServiceDataHolder.getInstance().setService(null);
     }
 
+
+    protected void setAddressRetriever(IpAddressRetriever ipAddressRetriever){
+
+        String loadClassName = AndesConfigurationManager.readValue(AndesConfiguration.DYNAMIC_DISCOVERY);
+        if (ipAddressRetriever.getClass().getName().equals(loadClassName)) {
+            AndesContext.getInstance().setAddressRetriever(ipAddressRetriever);
+        }
+    }
+
+
+    protected void unsetAddressRetriever(IpAddressRetriever ipAddressRetriever){
+        AndesContext.getInstance().setAddressRetriever(null);
+
+    }
     /**
      * Shutdown from the carbon kernel level.
      */

--- a/components/extensions/org.wso2.carbon.messaging.extensions.dynamic-discovery/pom.xml
+++ b/components/extensions/org.wso2.carbon.messaging.extensions.dynamic-discovery/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.wso2.carbon.messaging</groupId>
+        <artifactId>extensions</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.carbon.messaging.extensions.dynamic-discovery</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Component - Extensions</name>
+    <description>Carbonized Andes</description>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.andes.wso2</groupId>
+            <artifactId>andes</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-ec2</artifactId>
+            <version>1.10.50</version>
+        </dependency>
+
+
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.8.4</version>
+        </dependency>
+
+
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.4</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.messaging</groupId>
+            <artifactId>org.wso2.carbon.andes</artifactId>
+        </dependency>
+
+
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <version>1.7.4</version>
+                <executions>
+                    <execution>
+                        <id>generate-scr-descriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.wso2.carbon.messaging.extensions.dynamicdiscovery.*
+                        </Export-Package>
+                        <Import-Package>
+                            org.wso2.andes.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+
+</project>

--- a/components/extensions/org.wso2.carbon.messaging.extensions.dynamic-discovery/src/main/java/org/wso2/carbon/messaging/extensions/dynamicdiscovery/ActivatorDynamicDisvovery.java
+++ b/components/extensions/org.wso2.carbon.messaging.extensions.dynamic-discovery/src/main/java/org/wso2/carbon/messaging/extensions/dynamicdiscovery/ActivatorDynamicDisvovery.java
@@ -1,0 +1,42 @@
+package org.wso2.carbon.messaging.extensions.dynamicdiscovery;
+
+
+import org.osgi.framework.BundleException;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.andes.server.cluster.IpAddressRetriever;
+
+
+/**
+ * @scr.component
+ *              name="org.wso2.carbon.extensions.dynamicdiscovery.ActivatorDynamicDiscovery"
+ *              immediate="true"
+ */
+public class ActivatorDynamicDisvovery {
+
+    private IpAddressRetriever ipAddressRetriever;
+    protected final Logger logger = LoggerFactory.getLogger(ActivatorDynamicDisvovery.class);
+
+
+    protected void activate(ComponentContext ctx) {
+
+
+            AwsCluster awsCluster = new AwsCluster();
+            ctx.getBundleContext().registerService(IpAddressRetriever.class.getName(),awsCluster,null);
+
+    }
+
+
+
+    /**
+     * Unregister OSGi services that were registered at the time of activation
+     * @param ctx component context
+     * @throws BundleException
+     */
+    protected void deactivate(ComponentContext ctx) throws BundleException {
+            ctx.getBundleContext().getBundle().stop();
+
+    }
+
+}

--- a/components/extensions/org.wso2.carbon.messaging.extensions.dynamic-discovery/src/main/java/org/wso2/carbon/messaging/extensions/dynamicdiscovery/AwsCluster.java
+++ b/components/extensions/org.wso2.carbon.messaging.extensions.dynamic-discovery/src/main/java/org/wso2/carbon/messaging/extensions/dynamicdiscovery/AwsCluster.java
@@ -1,0 +1,31 @@
+package org.wso2.carbon.messaging.extensions.dynamicdiscovery;
+
+import com.amazonaws.util.EC2MetadataUtils;
+import org.wso2.andes.server.cluster.IpAddressRetriever;
+import org.wso2.andes.server.cluster.MultipleAddressDetails;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class AwsCluster implements IpAddressRetriever {
+
+    private List<MultipleAddressDetails> multipleAddressDetailsList = new ArrayList<>();
+
+    public List<MultipleAddressDetails> getLocalAddress() {
+
+            String publicAddress = EC2MetadataUtils.getData("/latest/meta-data/public-ipv4");
+        MultipleAddressDetails multipleAddressDetails = new MultipleAddressDetails("public",publicAddress);
+        multipleAddressDetailsList.add(multipleAddressDetails);
+
+
+        String privateAddress = EC2MetadataUtils.getPrivateIpAddress();
+        MultipleAddressDetails multipleAddressDetails1 = new MultipleAddressDetails("private",privateAddress);
+        multipleAddressDetailsList.add(multipleAddressDetails1);
+
+        return multipleAddressDetailsList;
+
+    }
+
+
+}

--- a/components/extensions/pom.xml
+++ b/components/extensions/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    # Copyright 2015 WSO2 Inc. (http://wso2.org)
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    # http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.messaging</groupId>
+        <artifactId>business-messaging</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>extensions</artifactId>
+    <packaging>pom</packaging>
+    <version>3.2.0-SNAPSHOT</version>
+    <name>WSO2 Carbon - Component - Extensions - Module</name>
+    <description>Messaging Extensions related components</description>
+    <url>http://wso2.org</url>
+
+    <modules>
+        <module>org.wso2.carbon.messaging.extensions.dynamic-discovery</module>
+    </modules>
+
+</project>

--- a/features/andes/org.wso2.carbon.andes.server.feature/pom.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/pom.xml
@@ -186,6 +186,10 @@
             <artifactId>org.wso2.carbon.identity.oauth.stub</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.messaging</groupId>
+            <artifactId>org.wso2.carbon.andes.dynamic-discovery</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
         </dependency>
@@ -331,6 +335,7 @@
                                 <bundleDef>org.apache.axis2.transport:axis2-transport-jms:${axis2.transport.jms.version}</bundleDef>
                                 <bundleDef>org.apache.axis2.transport:axis2-transport-rabbitmq-amqp:${axis2.transport.rabbitmq.amqp.version}</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity:org.wso2.carbon.identity.oauth.stub:${carbon.identity.oauth.stub.version}</bundleDef>
+                                <bundleDef>org.wso2.carbon.messaging:org.wso2.carbon.andes.dynamic-discovery:${carbon.messaging.version}</bundleDef>
                                 <bundleDef>org.apache.commons:commons-pool2:${org.apache.commons.pool.version}</bundleDef>
                             </bundles>
                             <importFeatures>

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -94,6 +94,7 @@ This file is ciphertool compliant. Refer PRODUCT_HOME/repository/conf/security/c
             <maximumRedeliveryAttempts>10</maximumRedeliveryAttempts>
             <allowSharedTopicSubscriptions>false</allowSharedTopicSubscriptions>
             <allowStrictNameValidation>true</allowStrictNameValidation>
+            <dynamicDiscovery>org.wso2.carbon.andes.discovery.LocalCluster</dynamicDiscovery>
 
             <!-- Refer repository/conf/advanced/qpid-config.xml for further AMQP-specific configurations.-->
         </amqp>

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/dbscripts/h2-mb.sql
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/dbscripts/h2-mb.sql
@@ -186,4 +186,18 @@ CREATE TABLE IF NOT EXISTS MB_MEMBERSHIP (
                         PRIMARY KEY (EVENT_ID)
 );
 
+CREATE TABLE IF NOT EXISTS NODE_DETAIL_TABLE (
+                         NODE_IDENTIFIER VARCHAR(512) NOT NULL,
+                         NODE_PORT INT,
+                         NODE_SSL_PORT INT,
+                         PRIMARY KEY (NODE_IDENTIFIER)
+);
+
+CREATE TABLE IF NOT EXISTS ADDRESS_DETAIL_TABLE (
+                         NODE_IDENTIFIER VARCHAR(512),
+                         NODE_INTERFACE VARCHAR(512),
+                         NODE_ADDRESS VARCHAR(512),
+                         FOREIGN KEY (NODE_IDENTIFIER) REFERENCES NODE_DETAIL_TABLE (NODE_IDENTIFIER)
+                         ON DELETE CASCADE
+);
 -- End of Andes Context Store Tables --

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/dbscripts/mysql-mb.sql
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/dbscripts/mysql-mb.sql
@@ -191,4 +191,21 @@ CREATE TABLE IF NOT EXISTS MB_CLUSTER_EVENT (
                         PRIMARY KEY (EVENT_ID)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+CREATE TABLE IF NOT EXISTS NODE_DETAIL_TABLE (
+                        NODE_IDENTIFIER VARCHAR(512),
+                        NODE_PORT INT,
+                        NODE_SSL_PORT INT,
+                        PRIMARY KEY (NODE_IDENTIFIER)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+
+
+CREATE TABLE IF NOT EXISTS ADDRESS_DETAIL_TABLE (
+                        NODE_IDENTIFIER VARCHAR(512),
+                        NODE_INTERFACE VARCHAR(512),
+                        NODE_ADDRESS VARCHAR(512),
+                        FOREIGN KEY (NODE_IDENTIFIER) REFERENCES NODE_DETAIL_TABLE (NODE_IDENTIFIER)
+                        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
 -- End of Andes Context Store Tables --

--- a/features/extensions/etc/feature.properties
+++ b/features/extensions/etc/feature.properties
@@ -1,0 +1,242 @@
+################################################################################
+# Copyright 2014 WSO2, Inc. (http://wso2.com)
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+providerName=WSO2 Inc.
+
+########################## license properties ##################################
+licenseURL=http://www.apache.org/licenses/LICENSE-2.0
+
+license=\
+                                 Apache License\n\
+                           Version 2.0, January 2004\n\
+                        http://www.apache.org/licenses/\n\
+\n\
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\
+\n\
+   1. Definitions.\n\
+\n\
+      "License" shall mean the terms and conditions for use, reproduction,\n\
+      and distribution as defined by Sections 1 through 9 of this document.\n\
+\n\
+      "Licensor" shall mean the copyright owner or entity authorized by\n\
+      the copyright owner that is granting the License.\n\
+\n\
+      "Legal Entity" shall mean the union of the acting entity and all\n\
+      other entities that control, are controlled by, or are under common\n\
+      control with that entity. For the purposes of this definition,\n\
+      "control" means (i) the power, direct or indirect, to cause the\n\
+      direction or management of such entity, whether by contract or\n\
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n\
+      outstanding shares, or (iii) beneficial ownership of such entity.\n\
+\n\
+      "You" (or "Your") shall mean an individual or Legal Entity\n\
+      exercising permissions granted by this License.\n\
+\n\
+      "Source" form shall mean the preferred form for making modifications,\n\
+      including but not limited to software source code, documentation\n\
+      source, and configuration files.\n\
+\n\
+      "Object" form shall mean any form resulting from mechanical\n\
+      transformation or translation of a Source form, including but\n\
+      not limited to compiled object code, generated documentation,\n\
+      and conversions to other media types.\n\
+\n\
+      "Work" shall mean the work of authorship, whether in Source or\n\
+      Object form, made available under the License, as indicated by a\n\
+      copyright notice that is included in or attached to the work\n\
+      (an example is provided in the Appendix below).\n\
+\n\
+      "Derivative Works" shall mean any work, whether in Source or Object\n\
+      form, that is based on (or derived from) the Work and for which the\n\
+      editorial revisions, annotations, elaborations, or other modifications\n\
+      represent, as a whole, an original work of authorship. For the purposes\n\
+      of this License, Derivative Works shall not include works that remain\n\
+      separable from, or merely link (or bind by name) to the interfaces of,\n\
+      the Work and Derivative Works thereof.\n\
+\n\
+      "Contribution" shall mean any work of authorship, including\n\
+      the original version of the Work and any modifications or additions\n\
+      to that Work or Derivative Works thereof, that is intentionally\n\
+      submitted to Licensor for inclusion in the Work by the copyright owner\n\
+      or by an individual or Legal Entity authorized to submit on behalf of\n\
+      the copyright owner. For the purposes of this definition, "submitted"\n\
+      means any form of electronic, verbal, or written communication sent\n\
+      to the Licensor or its representatives, including but not limited to\n\
+      communication on electronic mailing lists, source code control systems,\n\
+      and issue tracking systems that are managed by, or on behalf of, the\n\
+      Licensor for the purpose of discussing and improving the Work, but\n\
+      excluding communication that is conspicuously marked or otherwise\n\
+      designated in writing by the copyright owner as "Not a Contribution."\n\
+\n\
+      "Contributor" shall mean Licensor and any individual or Legal Entity\n\
+      on behalf of whom a Contribution has been received by Licensor and\n\
+      subsequently incorporated within the Work.\n\
+\n\
+   2. Grant of Copyright License. Subject to the terms and conditions of\n\
+      this License, each Contributor hereby grants to You a perpetual,\n\
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n\
+      copyright license to reproduce, prepare Derivative Works of,\n\
+      publicly display, publicly perform, sublicense, and distribute the\n\
+      Work and such Derivative Works in Source or Object form.\n\
+\n\
+   3. Grant of Patent License. Subject to the terms and conditions of\n\
+      this License, each Contributor hereby grants to You a perpetual,\n\
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n\
+      (except as stated in this section) patent license to make, have made,\n\
+      use, offer to sell, sell, import, and otherwise transfer the Work,\n\
+      where such license applies only to those patent claims licensable\n\
+      by such Contributor that are necessarily infringed by their\n\
+      Contribution(s) alone or by combination of their Contribution(s)\n\
+      with the Work to which such Contribution(s) was submitted. If You\n\
+      institute patent litigation against any entity (including a\n\
+      cross-claim or counterclaim in a lawsuit) alleging that the Work\n\
+      or a Contribution incorporated within the Work constitutes direct\n\
+      or contributory patent infringement, then any patent licenses\n\
+      granted to You under this License for that Work shall terminate\n\
+      as of the date such litigation is filed.\n\
+\n\
+   4. Redistribution. You may reproduce and distribute copies of the\n\
+      Work or Derivative Works thereof in any medium, with or without\n\
+      modifications, and in Source or Object form, provided that You\n\
+      meet the following conditions:\n\
+\n\
+      (a) You must give any other recipients of the Work or\n\
+          Derivative Works a copy of this License; and\n\
+\n\
+      (b) You must cause any modified files to carry prominent notices\n\
+          stating that You changed the files; and\n\
+\n\
+      (c) You must retain, in the Source form of any Derivative Works\n\
+          that You distribute, all copyright, patent, trademark, and\n\
+          attribution notices from the Source form of the Work,\n\
+          excluding those notices that do not pertain to any part of\n\
+          the Derivative Works; and\n\
+\n\
+      (d) If the Work includes a "NOTICE" text file as part of its\n\
+          distribution, then any Derivative Works that You distribute must\n\
+          include a readable copy of the attribution notices contained\n\
+          within such NOTICE file, excluding those notices that do not\n\
+          pertain to any part of the Derivative Works, in at least one\n\
+          of the following places: within a NOTICE text file distributed\n\
+          as part of the Derivative Works; within the Source form or\n\
+          documentation, if provided along with the Derivative Works; or,\n\
+          within a display generated by the Derivative Works, if and\n\
+          wherever such third-party notices normally appear. The contents\n\
+          of the NOTICE file are for informational purposes only and\n\
+          do not modify the License. You may add Your own attribution\n\
+          notices within Derivative Works that You distribute, alongside\n\
+          or as an addendum to the NOTICE text from the Work, provided\n\
+          that such additional attribution notices cannot be construed\n\
+          as modifying the License.\n\
+\n\
+      You may add Your own copyright statement to Your modifications and\n\
+      may provide additional or different license terms and conditions\n\
+      for use, reproduction, or distribution of Your modifications, or\n\
+      for any such Derivative Works as a whole, provided Your use,\n\
+      reproduction, and distribution of the Work otherwise complies with\n\
+      the conditions stated in this License.\n\
+\n\
+   5. Submission of Contributions. Unless You explicitly state otherwise,\n\
+      any Contribution intentionally submitted for inclusion in the Work\n\
+      by You to the Licensor shall be under the terms and conditions of\n\
+      this License, without any additional terms or conditions.\n\
+      Notwithstanding the above, nothing herein shall supersede or modify\n\
+      the terms of any separate license agreement you may have executed\n\
+      with Licensor regarding such Contributions.\n\
+\n\
+   6. Trademarks. This License does not grant permission to use the trade\n\
+      names, trademarks, service marks, or product names of the Licensor,\n\
+      except as required for reasonable and customary use in describing the\n\
+      origin of the Work and reproducing the content of the NOTICE file.\n\
+\n\
+   7. Disclaimer of Warranty. Unless required by applicable law or\n\
+      agreed to in writing, Licensor provides the Work (and each\n\
+      Contributor provides its Contributions) on an "AS IS" BASIS,\n\
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n\
+      implied, including, without limitation, any warranties or conditions\n\
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n\
+      PARTICULAR PURPOSE. You are solely responsible for determining the\n\
+      appropriateness of using or redistributing the Work and assume any\n\
+      risks associated with Your exercise of permissions under this License.\n\
+\n\
+   8. Limitation of Liability. In no event and under no legal theory,\n\
+      whether in tort (including negligence), contract, or otherwise,\n\
+      unless required by applicable law (such as deliberate and grossly\n\
+      negligent acts) or agreed to in writing, shall any Contributor be\n\
+      liable to You for damages, including any direct, indirect, special,\n\
+      incidental, or consequential damages of any character arising as a\n\
+      result of this License or out of the use or inability to use the\n\
+      Work (including but not limited to damages for loss of goodwill,\n\
+      work stoppage, computer failure or malfunction, or any and all\n\
+      other commercial damages or losses), even if such Contributor\n\
+      has been advised of the possibility of such damages.\n\
+\n\
+   9. Accepting Warranty or Additional Liability. While redistributing\n\
+      the Work or Derivative Works thereof, You may choose to offer,\n\
+      and charge a fee for, acceptance of support, warranty, indemnity,\n\
+      or other liability obligations and/or rights consistent with this\n\
+      License. However, in accepting such obligations, You may act only\n\
+      on Your own behalf and on Your sole responsibility, not on behalf\n\
+      of any other Contributor, and only if You agree to indemnify,\n\
+      defend, and hold each Contributor harmless for any liability\n\
+      incurred by, or claims asserted against, such Contributor by reason\n\
+      of your accepting any such warranty or additional liability.\n\
+\n\
+   END OF TERMS AND CONDITIONS\n\
+\n\
+   APPENDIX: How to apply the Apache License to your work.\n\
+\n\
+      To apply the Apache License to your work, attach the following\n\
+      boilerplate notice, with the fields enclosed by brackets "[]"\n\
+      replaced with your own identifying information. (Don't include\n\
+      the brackets!)  The text should be enclosed in the appropriate\n\
+      comment syntax for the file format. We also recommend that a\n\
+      file or class name and description of purpose be included on the\n\
+      same "printed page" as the copyright notice for easier\n\
+      identification within third-party archives.\n\
+\n\
+   Copyright [yyyy] [name of copyright owner]\n\
+\n\
+   Licensed under the Apache License, Version 2.0 (the "License");\n\
+   you may not use this file except in compliance with the License.\n\
+   You may obtain a copy of the License at\n\
+\n\
+       http://www.apache.org/licenses/LICENSE-2.0\n\
+\n\
+   Unless required by applicable law or agreed to in writing, software\n\
+   distributed under the License is distributed on an "AS IS" BASIS,\n\
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n\
+   See the License for the specific language governing permissions and\n\
+   limitations under the License.\n
+
+######################### copyright properties #################################
+copyrightURL=TODO
+
+copyright=\
+Copyright (c) WSO2 Inc. (http://wso2.com)\n\
+\n\
+Licensed under the Apache License, Version 2.0 (the "License");\n\
+you may not use this file except in compliance with the License.\n\
+You may obtain a copy of the License at\n\
+\n\
+http://www.apache.org/licenses/LICENSE-2.0\n\
+\n\
+Unless required by applicable law or agreed to in writing, software\n\
+distributed under the License is distributed on an "AS IS" BASIS,\n\
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n\
+See the License for the specific language governing permissions and\n\
+limitations under the License.\n
+

--- a/features/extensions/org.wso2.carbon.messaging.extensions.dynamic-discovery.feature/pom.xml
+++ b/features/extensions/org.wso2.carbon.messaging.extensions.dynamic-discovery.feature/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>business-messaging</artifactId>
+        <groupId>org.wso2.carbon.messaging</groupId>
+        <version>3.2.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.messaging.extensions.dynamic-discovery.feature</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>WSO2 Carbon - Feature - Extensions</name>
+    <url>http://wso2.org</url>
+    <description>This feature provides Extensions features</description>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.messaging</groupId>
+            <artifactId>org.wso2.carbon.messaging.extensions.dynamic-discovery</artifactId>
+            <version>3.2.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>carbon-p2-plugin</artifactId>
+                <version>${carbon.p2.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>4-p2-feature-generation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>p2-feature-gen</goal>
+                        </goals>
+                        <configuration>
+                            <id>org.wso2.carbon.messaging.extensions.dynamic-discovery</id>
+                            <propertiesFile>../etc/feature.properties</propertiesFile>
+                            <adviceFile>
+                                <properties>
+                                    <propertyDef>org.eclipse.equinox.p2.type.group:true
+                                    </propertyDef>
+                                </properties>
+                            </adviceFile>
+                            <bundles>
+                                <bundleDef>org.wso2.carbon.messaging:org.wso2.carbon.messaging.extensions.dynamic-discovery:3.2.0-SNAPSHOT</bundleDef>
+                            </bundles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+
+
+</project>

--- a/features/extensions/pom.xml
+++ b/features/extensions/pom.xml
@@ -27,29 +27,13 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>andes</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>extensions-feature</artifactId>
     <version>3.2.0-SNAPSHOT</version>
-    <name>WSO2 Carbon - Component - Andes - Aggregator Module</name>
-    <description>
-        This is a Carbon bundle that represents the Andes module
-    </description>
+    <packaging>pom</packaging>
+    <name>WSO2 Carbon - Feature - Extensions Aggregator Module</name>
     <url>http://wso2.org</url>
 
     <modules>
-        <module>org.wso2.carbon.andes.commons</module>
-        <module>org.wso2.carbon.andes.authentication</module>
-        <module>org.wso2.carbon.andes</module>
-        <module>org.wso2.carbon.andes.authorization</module>
-        <module>org.wso2.carbon.andes.cluster.mgt</module>
-        <module>org.wso2.carbon.andes.cluster.mgt.ui</module>
-        <module>org.wso2.carbon.andes.core</module>
-        <module>org.wso2.carbon.andes.admin</module>
-        <module>org.wso2.carbon.andes.ui</module>
-        <module>org.wso2.carbon.andes.event.core</module>
-        <module>org.wso2.carbon.andes.event.admin</module>
-        <module>org.wso2.carbon.andes.event.ui</module>
-        <module>org.wso2.carbon.andes.dynamic-discovery</module>
+        <module>org.wso2.carbon.messaging.extensions.dynamic-discovery.feature</module>
     </modules>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,10 @@
         <module>service-stubs</module>
         <module>components/andes</module>
         <module>components/metrics</module>
+        <module>components/extensions</module>
         <module>features/andes</module>
         <module>features/metrics</module>
+        <module>features/extensions</module>
     </modules>
 
     <scm>
@@ -658,6 +660,11 @@
                 <groupId>commons-httpclient.wso2</groupId>
                 <artifactId>commons-httpclient</artifactId>
                 <version>${orbit.version.commons.httpclient}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.messaging</groupId>
+                <artifactId>org.wso2.carbon.andes.dynamic-discovery</artifactId>
+                <version>${carbon.messaging.version}</version>
             </dependency>
             <dependency>
                  <groupId>org.apache.commons</groupId>

--- a/service-stubs/org.wso2.carbon.andes.mgt.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.andes.mgt.stub/pom.xml
@@ -94,7 +94,8 @@
 						<Private-Package>
 						</Private-Package>
 						<Export-Package>
-							org.wso2.carbon.andes.mgt.stub.*;version="${andes.export.version}"
+							org.wso2.carbon.andes.mgt.stub.*;version="${andes.export.version}",
+							org.wso2.carbon.andes.cluster.mgt.internal.xsd.*;version="${andes.export.version}"
 						</Export-Package>
 						<Import-Package>
 							!org.wso2.carbon.andes.mgt.*,

--- a/service-stubs/org.wso2.carbon.andes.mgt.stub/src/main/resources/AndesManagerService.wsdl
+++ b/service-stubs/org.wso2.carbon.andes.mgt.stub/src/main/resources/AndesManagerService.wsdl
@@ -1,4 +1,4 @@
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:ns="http://mgt.cluster.andes.carbon.wso2.org" xmlns:ax27="http://mgt.cluster.andes.carbon.wso2.org/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:ax25="http://internal.mgt.cluster.andes.carbon.wso2.org/xsd" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" targetNamespace="http://mgt.cluster.andes.carbon.wso2.org">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax27="http://mgt.cluster.andes.carbon.wso2.org/xsd" xmlns:ns="http://mgt.cluster.andes.carbon.wso2.org" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:ax25="http://internal.mgt.cluster.andes.carbon.wso2.org/xsd" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://mgt.cluster.andes.carbon.wso2.org">
     <wsdl:documentation>AndesManagerService</wsdl:documentation>
     <wsdl:types>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://mgt.cluster.andes.carbon.wso2.org/xsd">
@@ -22,19 +22,7 @@
             <xs:element name="AndesManagerServiceClusterMgtException">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="ClusterMgtException" nillable="true" type="ax25:ClusterMgtException"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMyNodeID">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMyNodeIDResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="ClusterMgtException" nillable="true" type="ax26:ClusterMgtException"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -50,10 +38,22 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="getMyNodeID">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMyNodeIDResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="AndesManagerServiceClusterMgtAdminException">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="ClusterMgtAdminException" nillable="true" type="ax27:ClusterMgtAdminException"/>
+                        <xs:element minOccurs="0" name="ClusterMgtAdminException" nillable="true" type="ax28:ClusterMgtAdminException"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -66,6 +66,18 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getBrokerInformation">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getBrokerInformationResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -92,14 +104,20 @@
     <wsdl:message name="AndesManagerServiceClusterMgtAdminException">
         <wsdl:part name="parameters" element="ns:AndesManagerServiceClusterMgtAdminException"/>
     </wsdl:message>
+    <wsdl:message name="isClusteringEnabledRequest">
+        <wsdl:part name="parameters" element="ns:isClusteringEnabled"/>
+    </wsdl:message>
+    <wsdl:message name="isClusteringEnabledResponse">
+        <wsdl:part name="parameters" element="ns:isClusteringEnabledResponse"/>
+    </wsdl:message>
+    <wsdl:message name="AndesManagerServiceClusterMgtException">
+        <wsdl:part name="parameters" element="ns:AndesManagerServiceClusterMgtException"/>
+    </wsdl:message>
     <wsdl:message name="getStoreHealthRequest">
         <wsdl:part name="parameters" element="ns:getStoreHealth"/>
     </wsdl:message>
     <wsdl:message name="getStoreHealthResponse">
         <wsdl:part name="parameters" element="ns:getStoreHealthResponse"/>
-    </wsdl:message>
-    <wsdl:message name="AndesManagerServiceClusterMgtException">
-        <wsdl:part name="parameters" element="ns:AndesManagerServiceClusterMgtException"/>
     </wsdl:message>
     <wsdl:message name="getMyNodeIDRequest">
         <wsdl:part name="parameters" element="ns:getMyNodeID"/>
@@ -107,17 +125,22 @@
     <wsdl:message name="getMyNodeIDResponse">
         <wsdl:part name="parameters" element="ns:getMyNodeIDResponse"/>
     </wsdl:message>
-    <wsdl:message name="isClusteringEnabledRequest">
-        <wsdl:part name="parameters" element="ns:isClusteringEnabled"/>
+    <wsdl:message name="getBrokerInformationRequest">
+        <wsdl:part name="parameters" element="ns:getBrokerInformation"/>
     </wsdl:message>
-    <wsdl:message name="isClusteringEnabledResponse">
-        <wsdl:part name="parameters" element="ns:isClusteringEnabledResponse"/>
+    <wsdl:message name="getBrokerInformationResponse">
+        <wsdl:part name="parameters" element="ns:getBrokerInformationResponse"/>
     </wsdl:message>
     <wsdl:portType name="AndesManagerServicePortType">
         <wsdl:operation name="getAllClusterNodeAddresses">
             <wsdl:input message="ns:getAllClusterNodeAddressesRequest" wsaw:Action="urn:getAllClusterNodeAddresses"/>
             <wsdl:output message="ns:getAllClusterNodeAddressesResponse" wsaw:Action="urn:getAllClusterNodeAddressesResponse"/>
             <wsdl:fault message="ns:AndesManagerServiceClusterMgtAdminException" name="AndesManagerServiceClusterMgtAdminException" wsaw:Action="urn:getAllClusterNodeAddressesAndesManagerServiceClusterMgtAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="isClusteringEnabled">
+            <wsdl:input message="ns:isClusteringEnabledRequest" wsaw:Action="urn:isClusteringEnabled"/>
+            <wsdl:output message="ns:isClusteringEnabledResponse" wsaw:Action="urn:isClusteringEnabledResponse"/>
+            <wsdl:fault message="ns:AndesManagerServiceClusterMgtException" name="AndesManagerServiceClusterMgtException" wsaw:Action="urn:isClusteringEnabledAndesManagerServiceClusterMgtException"/>
         </wsdl:operation>
         <wsdl:operation name="getStoreHealth">
             <wsdl:input message="ns:getStoreHealthRequest" wsaw:Action="urn:getStoreHealth"/>
@@ -129,10 +152,10 @@
             <wsdl:output message="ns:getMyNodeIDResponse" wsaw:Action="urn:getMyNodeIDResponse"/>
             <wsdl:fault message="ns:AndesManagerServiceClusterMgtException" name="AndesManagerServiceClusterMgtException" wsaw:Action="urn:getMyNodeIDAndesManagerServiceClusterMgtException"/>
         </wsdl:operation>
-        <wsdl:operation name="isClusteringEnabled">
-            <wsdl:input message="ns:isClusteringEnabledRequest" wsaw:Action="urn:isClusteringEnabled"/>
-            <wsdl:output message="ns:isClusteringEnabledResponse" wsaw:Action="urn:isClusteringEnabledResponse"/>
-            <wsdl:fault message="ns:AndesManagerServiceClusterMgtException" name="AndesManagerServiceClusterMgtException" wsaw:Action="urn:isClusteringEnabledAndesManagerServiceClusterMgtException"/>
+        <wsdl:operation name="getBrokerInformation">
+            <wsdl:input message="ns:getBrokerInformationRequest" wsaw:Action="urn:getBrokerInformation"/>
+            <wsdl:output message="ns:getBrokerInformationResponse" wsaw:Action="urn:getBrokerInformationResponse"/>
+            <wsdl:fault message="ns:AndesManagerServiceClusterMgtException" name="AndesManagerServiceClusterMgtException" wsaw:Action="urn:getBrokerInformationAndesManagerServiceClusterMgtException"/>
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="AndesManagerServiceSoap11Binding" type="ns:AndesManagerServicePortType">
@@ -147,6 +170,18 @@
             </wsdl:output>
             <wsdl:fault name="AndesManagerServiceClusterMgtAdminException">
                 <soap:fault use="literal" name="AndesManagerServiceClusterMgtAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="isClusteringEnabled">
+            <soap:operation soapAction="urn:isClusteringEnabled" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesManagerServiceClusterMgtException">
+                <soap:fault use="literal" name="AndesManagerServiceClusterMgtException"/>
             </wsdl:fault>
         </wsdl:operation>
         <wsdl:operation name="getStoreHealth">
@@ -173,8 +208,8 @@
                 <soap:fault use="literal" name="AndesManagerServiceClusterMgtException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="isClusteringEnabled">
-            <soap:operation soapAction="urn:isClusteringEnabled" style="document"/>
+        <wsdl:operation name="getBrokerInformation">
+            <soap:operation soapAction="urn:getBrokerInformation" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -198,6 +233,18 @@
             </wsdl:output>
             <wsdl:fault name="AndesManagerServiceClusterMgtAdminException">
                 <soap12:fault use="literal" name="AndesManagerServiceClusterMgtAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="isClusteringEnabled">
+            <soap12:operation soapAction="urn:isClusteringEnabled" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesManagerServiceClusterMgtException">
+                <soap12:fault use="literal" name="AndesManagerServiceClusterMgtException"/>
             </wsdl:fault>
         </wsdl:operation>
         <wsdl:operation name="getStoreHealth">
@@ -224,8 +271,8 @@
                 <soap12:fault use="literal" name="AndesManagerServiceClusterMgtException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="isClusteringEnabled">
-            <soap12:operation soapAction="urn:isClusteringEnabled" style="document"/>
+        <wsdl:operation name="getBrokerInformation">
+            <soap12:operation soapAction="urn:getBrokerInformation" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -241,6 +288,15 @@
         <http:binding verb="POST"/>
         <wsdl:operation name="getAllClusterNodeAddresses">
             <http:operation location="getAllClusterNodeAddresses"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="isClusteringEnabled">
+            <http:operation location="isClusteringEnabled"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -266,8 +322,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="isClusteringEnabled">
-            <http:operation location="isClusteringEnabled"/>
+        <wsdl:operation name="getBrokerInformation">
+            <http:operation location="getBrokerInformation"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -278,13 +334,13 @@
     </wsdl:binding>
     <wsdl:service name="AndesManagerService">
         <wsdl:port name="AndesManagerServiceHttpsSoap11Endpoint" binding="ns:AndesManagerServiceSoap11Binding">
-            <soap:address location="https://172.17.0.1:9443/services/AndesManagerService.AndesManagerServiceHttpsSoap11Endpoint/"/>
+            <soap:address location="https://10.100.4.165:9443/services/AndesManagerService.AndesManagerServiceHttpsSoap11Endpoint/"/>
         </wsdl:port>
         <wsdl:port name="AndesManagerServiceHttpsSoap12Endpoint" binding="ns:AndesManagerServiceSoap12Binding">
-            <soap12:address location="https://172.17.0.1:9443/services/AndesManagerService.AndesManagerServiceHttpsSoap12Endpoint/"/>
+            <soap12:address location="https://10.100.4.165:9443/services/AndesManagerService.AndesManagerServiceHttpsSoap12Endpoint/"/>
         </wsdl:port>
         <wsdl:port name="AndesManagerServiceHttpsEndpoint" binding="ns:AndesManagerServiceHttpBinding">
-            <http:address location="https://172.17.0.1:9443/services/AndesManagerService.AndesManagerServiceHttpsEndpoint/"/>
+            <http:address location="https://10.100.4.165:9443/services/AndesManagerService.AndesManagerServiceHttpsEndpoint/"/>
         </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>


### PR DESCRIPTION
**Dynamic discovery of broker nodes in cluster project server side implementation.**

In MB, the user/developers having to manually list out the IPs in the connection URL could be difficult. The change of IPs of the broker nodes would require reconfiguring and restart the client applications connected to it. I am implementing a way to dynamically detection the MB nodes in the cluster and load balance through them.

I got the IP address(all network interfaces) and AMQP ports(with SSL) and store database at cluster startup. When node shutdown that details are removed from the database.
I wrote an admin service to get those database details at the carbon business module.

In Andes client [1], I implemented a new initialContextFactory and inside that, I made an AMQP URL

[1] https://github.com/wso2/andes/pull/741
