### PR TITLE
Made queue names case insensitive

### DIFF
--- a/components/andes/org.wso2.carbon.andes.admin/src/main/java/org/wso2/carbon/andes/admin/AndesAdminService.java
+++ b/components/andes/org.wso2.carbon.andes.admin/src/main/java/org/wso2/carbon/andes/admin/AndesAdminService.java
@@ -115,6 +115,7 @@ public class AndesAdminService extends AbstractAdmin {
      */
     public org.wso2.carbon.andes.admin.internal.Queue getQueueByName(String queueName)
             throws BrokerManagerAdminException {
+        queueName = setNameToLowerCase(queueName);
         org.wso2.carbon.andes.admin.internal.Queue queue = null;
         try {
 
@@ -221,6 +222,7 @@ public class AndesAdminService extends AbstractAdmin {
     @SuppressWarnings("UnusedDeclaration")
     public long getMessageCount(String destinationName, String msgPattern)
             throws BrokerManagerAdminException {
+        destinationName = setNameToLowerCase(destinationName);
         long messageCount;
         try {
             QueueManagerService queueManagerService =
@@ -241,6 +243,7 @@ public class AndesAdminService extends AbstractAdmin {
      * @throws BrokerManagerAdminException
      */
     public void deleteQueue(String queueName) throws BrokerManagerAdminException {
+        queueName = setNameToLowerCase(queueName);
         try {
             QueueManagerService queueManagerService =
                     AndesBrokerManagerAdminServiceDSHolder.getInstance().getQueueManagerService();
@@ -259,6 +262,8 @@ public class AndesAdminService extends AbstractAdmin {
      * @throws BrokerManagerAdminException
      */
     public void deleteTopicFromRegistry(String topicName, String subscriptionId) throws BrokerManagerAdminException {
+        topicName = setNameToLowerCase(topicName);
+        subscriptionId = setNameToLowerCase(subscriptionId);
         try {
             QueueManagerService queueManagerService =
                     AndesBrokerManagerAdminServiceDSHolder.getInstance().getQueueManagerService();
@@ -280,6 +285,7 @@ public class AndesAdminService extends AbstractAdmin {
      */
     public long restoreMessagesFromDeadLetterQueue(long[] messageIDs, String destinationQueueName)
             throws BrokerManagerAdminException {
+        destinationQueueName = setNameToLowerCase(destinationQueueName);
         try {
             QueueManagerService queueManagerService =
                     AndesBrokerManagerAdminServiceDSHolder.getInstance().getQueueManagerService();
@@ -304,6 +310,8 @@ public class AndesAdminService extends AbstractAdmin {
                                                                            String newDestinationQueueName,
                                                                            String destinationQueueName)
             throws BrokerManagerAdminException {
+        newDestinationQueueName = setNameToLowerCase(newDestinationQueueName);
+        destinationQueueName = setNameToLowerCase(destinationQueueName);
         try {
             QueueManagerService queueManagerService =
                     AndesBrokerManagerAdminServiceDSHolder.getInstance().getQueueManagerService();
@@ -325,6 +333,7 @@ public class AndesAdminService extends AbstractAdmin {
      */
     public void deleteMessagesFromDeadLetterQueue(long[] messageIDs, String destinationQueueName)
             throws BrokerManagerAdminException {
+        destinationQueueName = setNameToLowerCase(destinationQueueName);
         try {
             QueueManagerService queueManagerService =
                     AndesBrokerManagerAdminServiceDSHolder.getInstance().getQueueManagerService();
@@ -343,6 +352,7 @@ public class AndesAdminService extends AbstractAdmin {
      * @throws BrokerManagerAdminException
      */
     public void purgeMessagesOfQueue(String queueName) throws BrokerManagerAdminException {
+        queueName = setNameToLowerCase(queueName);
         try {
             QueueManagerService queueManagerService =
                     AndesBrokerManagerAdminServiceDSHolder.getInstance().getQueueManagerService();
@@ -367,7 +377,10 @@ public class AndesAdminService extends AbstractAdmin {
 	public void closeSubscription(boolean isDurable, String subscriptionID, String subscribedQueueOrTopicName,
                                   String protocolType, String destinationType, String subscriberQueueName)
             throws BrokerManagerAdminException {
-		try {
+        subscriptionID = setNameToLowerCase(subscriptionID);
+        subscribedQueueOrTopicName = setNameToLowerCase(subscribedQueueOrTopicName);
+        subscriberQueueName = setNameToLowerCase(subscriberQueueName);
+        try {
 			SubscriptionManagerService subscriptionManagerService =
 					AndesBrokerManagerAdminServiceDSHolder.getInstance().getSubscriptionManagerService();
             subscriptionManagerService.closeSubscription(subscriptionID, subscribedQueueOrTopicName, protocolType,
@@ -505,6 +518,8 @@ public class AndesAdminService extends AbstractAdmin {
         List<Subscription> allSubscriptions = new ArrayList<>();
         Subscription[] subscriptionsDTO;
 
+        filteredNamePattern = setNameToLowerCase(filteredNamePattern);
+        identifierPattern = setNameToLowerCase(identifierPattern);
         try {
             SubscriptionManagerService subscriptionManagerService =
                     AndesBrokerManagerAdminServiceDSHolder.getInstance().getSubscriptionManagerService();
@@ -561,6 +576,8 @@ public class AndesAdminService extends AbstractAdmin {
                                                         isFilteredNameByExactMatch, String identifierPattern, boolean
                                                         isIdentifierPatternByExactMatch, String ownNodeId) throws
                                                         BrokerManagerAdminException {
+        filteredNamePattern = setNameToLowerCase(filteredNamePattern);
+        identifierPattern = setNameToLowerCase(identifierPattern);
         int subscriptionCountForSearchResult = 0;
         try {
             SubscriptionManagerService subscriptionManagerService =
@@ -590,6 +607,7 @@ public class AndesAdminService extends AbstractAdmin {
             throws BrokerManagerAdminException {
         QueueManagerService queueManagerService =
                 AndesBrokerManagerAdminServiceDSHolder.getInstance().getQueueManagerService();
+        queueName = setNameToLowerCase(queueName);
         try {
             return queueManagerService.getNumberOfMessagesInDLCForQueue(queueName);
         } catch (QueueManagerException e) {
@@ -614,6 +632,7 @@ public class AndesAdminService extends AbstractAdmin {
         QueueManagerService queueManagerService = AndesBrokerManagerAdminServiceDSHolder.getInstance()
                 .getQueueManagerService();
         List<Message> messageDTOList = new ArrayList<>();
+        queueName = setNameToLowerCase(queueName);
         try {
             org.wso2.carbon.andes.core.types.Message[] messages =
                     queueManagerService.getMessageInDLCForQueue(queueName, nextMessageIdToRead, maxMsgCount);
@@ -647,8 +666,8 @@ public class AndesAdminService extends AbstractAdmin {
      * @throws BrokerManagerAdminException
      */
     public void updatePermission(String queueName, QueueRolePermission[] queueRolePermissionsDTO)
-            throws
-            BrokerManagerAdminException {
+            throws BrokerManagerAdminException {
+        queueName = setNameToLowerCase(queueName);
         QueueManagerService queueManagerService = AndesBrokerManagerAdminServiceDSHolder.getInstance()
                 .getQueueManagerService();
         org.wso2.carbon.andes.core.types.QueueRolePermission[] rolePermissions;
@@ -680,6 +699,7 @@ public class AndesAdminService extends AbstractAdmin {
             throws BrokerManagerAdminException {
         QueueManagerService queueManagerService = AndesBrokerManagerAdminServiceDSHolder.getInstance()
                 .getQueueManagerService();
+        queueName = queueName.toLowerCase();
         org.wso2.carbon.andes.core.types.QueueRolePermission[] rolePermissions;
         try {
             if (null != queueRolePermissionsDTO && queueRolePermissionsDTO.length > 0) {
@@ -733,6 +753,7 @@ public class AndesAdminService extends AbstractAdmin {
             throws BrokerManagerAdminException {
         QueueManagerService queueManagerService = AndesBrokerManagerAdminServiceDSHolder.getInstance()
                 .getQueueManagerService();
+        queueName = setNameToLowerCase(queueName);
         List<QueueRolePermission> queueRolePermissionDTOList = new ArrayList<QueueRolePermission>();
         try {
             org.wso2.carbon.andes.core.types.QueueRolePermission[] queueRolePermission = queueManagerService
@@ -767,6 +788,7 @@ public class AndesAdminService extends AbstractAdmin {
         QueueManagerService queueManagerService = AndesBrokerManagerAdminServiceDSHolder.getInstance()
                 .getQueueManagerService();
         List<Message> messageDTOList = new ArrayList<Message>();
+        queueName = setNameToLowerCase(queueName);
         try {
             org.wso2.carbon.andes.core.types.Message[] messages =
                     queueManagerService.browseQueue(queueName, nextMessageIdToRead, maxMsgCount);
@@ -804,6 +826,7 @@ public class AndesAdminService extends AbstractAdmin {
     public long getTotalMessagesInQueue(String queueName) throws BrokerManagerAdminException {
         QueueManagerService queueManagerService = AndesBrokerManagerAdminServiceDSHolder.getInstance()
                 .getQueueManagerService();
+        queueName = setNameToLowerCase(queueName);
         try {
             return queueManagerService.getTotalMessagesInQueue(queueName);
         } catch (QueueManagerException e) {
@@ -834,6 +857,7 @@ public class AndesAdminService extends AbstractAdmin {
             throws BrokerManagerAdminException {
         QueueManagerService queueManagerService = AndesBrokerManagerAdminServiceDSHolder.getInstance()
                 .getQueueManagerService();
+        queueName = setNameToLowerCase(queueName);
         try {
             return queueManagerService.sendMessage(queueName, getCurrentLoggedInUser(), getAccessKey(), jmsType,
                     jmsCorrelationID, numberOfMessages, message, deliveryMode, priority, expireTime);
@@ -866,6 +890,7 @@ public class AndesAdminService extends AbstractAdmin {
     public int getMessageCountForSubscriber(String subscriptionID, boolean durable, String protocolType,
                                             String destinationType) throws BrokerManagerAdminException {
         int remainingMessages = 0;
+        subscriptionID = setNameToLowerCase(subscriptionID);
         try {
             SubscriptionManagerService subscriptionManagerService =
                     AndesBrokerManagerAdminServiceDSHolder.getInstance().getSubscriptionManagerService();
@@ -901,6 +926,7 @@ public class AndesAdminService extends AbstractAdmin {
      * @throws BrokerManagerAdminException
      */
     public long getPendingMessageCount(String queueName) throws BrokerManagerAdminException {
+        queueName = setNameToLowerCase(queueName);
         try {
             SubscriptionManagerService subscriptionManagerService =
                     AndesBrokerManagerAdminServiceDSHolder.getInstance().getSubscriptionManagerService();
@@ -941,6 +967,7 @@ public class AndesAdminService extends AbstractAdmin {
      */
     @SuppressWarnings("unused")
     public boolean checkCurrentUserHasPublishPermission(String queueName) throws BrokerManagerAdminException {
+        queueName = setNameToLowerCase(queueName);
         return checkUserHasPublishPermission(queueName, getCurrentLoggedInUser());
     }
 
@@ -954,6 +981,7 @@ public class AndesAdminService extends AbstractAdmin {
      */
     public boolean checkUserHasPublishPermission(String queueName, String userName) throws BrokerManagerAdminException {
         boolean hasPermission = false;
+        queueName = setNameToLowerCase(queueName);
         String queueID = CommonsUtil.getQueueID(queueName);
         try {
             if (Utils.isAdmin(userName)) {
@@ -1352,5 +1380,15 @@ public class AndesAdminService extends AbstractAdmin {
         public int compare(Subscription sub1, Subscription sub2) {
             return sub1.getNumberOfMessagesRemainingForSubscriber() - sub2.getNumberOfMessagesRemainingForSubscriber();
         }
+    }
+
+    /**
+     * Given a queue name this method returns the lower case representation of the queue name.
+     *
+     * @param queue the queue name to change the case
+     * @return the lower case representation of the queue name
+     */
+    private String setNameToLowerCase(String queue) {
+        return queue.toLowerCase();
     }
 }

--- a/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/internal/registry/QueueManagementBeans.java
+++ b/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/internal/registry/QueueManagementBeans.java
@@ -72,7 +72,6 @@ public class QueueManagementBeans {
     public void createQueue(String queueName, String userName) throws QueueManagerException {
         MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
         try {
-
             ObjectName objectName =
                     new ObjectName("org.wso2.andes:type=VirtualHost.VirtualHostManager,VirtualHost=\"carbon\"");
             String operationName = "createNewQueue";

--- a/components/andes/org.wso2.carbon.andes.event.admin/src/main/java/org/wso2/carbon/andes/event/admin/AndesEventAdminService.java
+++ b/components/andes/org.wso2.carbon.andes.event.admin/src/main/java/org/wso2/carbon/andes/event/admin/AndesEventAdminService.java
@@ -91,6 +91,7 @@ public class AndesEventAdminService extends AbstractAdmin {
      */
     @SuppressWarnings("UnusedDeclaration")
     public TopicRolePermission[] getTopicRolePermissions(String topic) throws EventAdminException {
+        topic = setNameToLowerCase(topic);
         EventBroker eventBroker = EventAdminHolder.getInstance().getEventBroker();
         try {
             return eventBroker.getTopicManagerService().getTopicRolePermission(topic);
@@ -108,6 +109,7 @@ public class AndesEventAdminService extends AbstractAdmin {
      * @throws EventAdminException Thrown when accessing registry or when providing permissions.
      */
     public void addTopic(String topic) throws EventAdminException {
+        topic = setNameToLowerCase(topic);
         EventBroker eventBroker = EventAdminHolder.getInstance().getEventBroker();
         try {
             if (!eventBroker.getTopicManagerService().isTopicExists(topic)) {
@@ -133,6 +135,7 @@ public class AndesEventAdminService extends AbstractAdmin {
     @SuppressWarnings("UnusedDeclaration")
     public void updatePermission(String topic, TopicRolePermission[] topicRolePermissions)
             throws EventAdminException {
+        topic = setNameToLowerCase(topic);
         EventBroker eventBroker = EventAdminHolder.getInstance().getEventBroker();
         try {
             eventBroker.getTopicManagerService().updatePermissions(topic, topicRolePermissions);
@@ -157,6 +160,7 @@ public class AndesEventAdminService extends AbstractAdmin {
     public Subscription[] getAllWSSubscriptionsForTopic(String topic, int startingIndex,
                                                         int maxSubscriptionCount)
             throws EventAdminException {
+        topic = setNameToLowerCase(topic);
         EventBroker eventBroker = EventAdminHolder.getInstance().getEventBroker();
         try {
             TopicManagerService topicManager = eventBroker.getTopicManagerService();
@@ -199,6 +203,7 @@ public class AndesEventAdminService extends AbstractAdmin {
      */
     @SuppressWarnings("UnusedDeclaration")
     public Subscription[] getWsSubscriptionsForTopic(String topic) throws EventAdminException {
+        topic = setNameToLowerCase(topic);
         EventBroker eventBroker = EventAdminHolder.getInstance().getEventBroker();
         try {
             return adaptSubscriptions(eventBroker.getTopicManagerService().getSubscriptions(topic, true));
@@ -219,6 +224,7 @@ public class AndesEventAdminService extends AbstractAdmin {
      */
     @SuppressWarnings("UnusedDeclaration")
     public int getAllWSSubscriptionCountForTopic(String topic) throws EventAdminException {
+        topic = setNameToLowerCase(topic);
         EventBroker eventBroker = EventAdminHolder.getInstance().getEventBroker();
         try {
             return eventBroker.getTopicManagerService().getSubscriptions(topic, true).length;
@@ -240,6 +246,7 @@ public class AndesEventAdminService extends AbstractAdmin {
     @SuppressWarnings("UnusedDeclaration")
     public Subscription[] getJMSSubscriptionsForTopic(String topic)
             throws EventAdminException {
+        topic = setNameToLowerCase(topic);
         EventBroker eventBroker = EventAdminHolder.getInstance().getEventBroker();
         try {
             return adaptSubscriptions(eventBroker.getTopicManagerService().getJMSSubscriptions(topic));
@@ -275,6 +282,7 @@ public class AndesEventAdminService extends AbstractAdmin {
      * @throws EventAdminException
      */
     public void publishToTopic(String content, String topicName) throws EventAdminException {
+        topicName = setNameToLowerCase(topicName);
         EventBroker eventBroker = EventAdminHolder.getInstance().getEventBroker();
         try {
             if (checkCurrentUserHasPublishTopicPermission(topicName)) {
@@ -390,6 +398,7 @@ public class AndesEventAdminService extends AbstractAdmin {
      * @throws EventAdminException
      */
     public boolean checkCurrentUserHasPublishTopicPermission(String topicName) throws EventAdminException {
+        topicName = setNameToLowerCase(topicName);
         return checkUserHasPublishTopicPermission(topicName, CarbonContext.getThreadLocalCarbonContext().getUsername());
     }
 
@@ -401,6 +410,7 @@ public class AndesEventAdminService extends AbstractAdmin {
      * @throws EventAdminException
      */
     public boolean checkUserHasPublishTopicPermission(String topicName, String username) throws EventAdminException {
+        topicName = setNameToLowerCase(topicName);
         EventBroker eventBroker = EventAdminHolder.getInstance().getEventBroker();
         try {
             return eventBroker.getTopicManagerService().checkUserHasPublishTopicPermission(topicName, username);
@@ -421,6 +431,7 @@ public class AndesEventAdminService extends AbstractAdmin {
      */
     @SuppressWarnings("UnusedDeclaration")
     public boolean removeTopic(String topic) throws EventAdminException {
+        topic = setNameToLowerCase(topic);
         EventBroker eventBroker = EventAdminHolder.getInstance().getEventBroker();
         try {
             return eventBroker.getTopicManagerService().removeTopic(topic);
@@ -483,5 +494,15 @@ public class AndesEventAdminService extends AbstractAdmin {
         adminSubscription.setTopicName(coreSubscription.getTopicName());
         adminSubscription.setMode(coreSubscription.getMode());
         return adminSubscription;
+    }
+
+    /**
+     * Given a queue name this method returns the lower case representation of the queue name.
+     *
+     * @param queue the queue name to change the case
+     * @return the lower case representation of the queue name
+     */
+    private String setNameToLowerCase(String queue) {
+        return queue.toLowerCase();
     }
 }


### PR DESCRIPTION
Queue names are turned to lower case when admin services are called as required for the change in https://github.com/wso2/andes/pull/831

Test case added in https://github.com/wso2/product-mb/pull/468