### PR TITLE
MB-1891 issue fixed.

### DIFF
--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/subscriptions/topic_subscriptions_list.jsp
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/subscriptions/topic_subscriptions_list.jsp
@@ -535,7 +535,7 @@ No subscriptions to show.
         <%
             String identifierForActiveSub = sub.getSubscriptionIdentifier();
             if (allowSharedSubscribers) {
-                identifierForActiveSub =  sub.getSubscriberQueueName() + "_" + sub.getSubscriptionIdentifier();
+                identifierForActiveSub =  sub.getSubscriptionIdentifier();
             }
         %>
         <td><%=identifierForActiveSub%>
@@ -642,7 +642,7 @@ No subscriptions to show.
         <%
             String identifierForInactiveSub = sub.getSubscriptionIdentifier();
             if (allowSharedSubscribers) {
-                identifierForInactiveSub =  sub.getSubscriberQueueName() + "_" + sub.getSubscriptionIdentifier();
+                identifierForInactiveSub =  sub.getSubscriptionIdentifier();
             }
         %>
         <td><%=identifierForInactiveSub%>


### PR DESCRIPTION
Remove subscription id prefix from the subscription list page. Due to this, filtering logic not working when do search by ID.