### PR TITLE
Removed hazelcast based slot agent configuration

### DIFF
--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -525,11 +525,6 @@ This file is ciphertool compliant. Refer PRODUCT_HOME/repository/conf/security/c
             <highLimit>1000</highLimit>
         </bufferBased>
     </flowControl>
-
-    <slotManagement>
-        <!--Set slot storage mode (RDBMS/HazelCast)-->
-        <storage>RDBMS</storage>
-    </slotManagement>
 	
     <!--
     Message broker keeps track of all messages it has received as groups. These groups are termed


### PR DESCRIPTION
Removed configuration in broker.xml to pick either Hazelcast slot agent or database slot agent. The changes in the classes are done in https://github.com/wso2/andes/pull/852 and seriaizer definitions are removed from axis2.xml in https://github.com/wso2/product-mb/pull/474