### PR TITLE
[MB-1737] - retrieve DLC messages without content for admin service purposes

### DIFF
--- a/components/andes/org.wso2.carbon.andes.admin/src/main/resources/META-INF/services.xml
+++ b/components/andes/org.wso2.carbon.andes.admin/src/main/resources/META-INF/services.xml
@@ -116,10 +116,10 @@
         <operation name="deleteTopicFromRegistry">
             <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/topic/delete</parameter>
         </operation>
-        <operation name="restoreMessagesFromDeadLetterQueue">
+        <operation name="restoreSelectedMessagesFromDeadLetterChannel">
             <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/dlc/restore</parameter>
         </operation>
-        <operation name="restoreMessagesFromDeadLetterQueueWithDifferentDestination">
+        <operation name="rerouteSelectedMessagesFromDeadLetterChannel">
             <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/dlc/reroute</parameter>
         </operation>
         <operation name="deleteMessagesFromDeadLetterQueue">
@@ -128,7 +128,7 @@
         <operation name="getNumberOfMessagesInDLCForQueue">
             <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/dlc/browse,/permission/admin/manage/dlc/delete,/permission/admin/manage/dlc/restore,/permission/admin/manage/dlc/reroute</parameter>
         </operation>
-        <operation name="getMessageInDLCForQueue">
+        <operation name="getMessagesInDLCForQueue">
             <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/dlc/browse,/permission/admin/manage/dlc/delete,/permission/admin/manage/dlc/restore,/permission/admin/manage/dlc/reroute</parameter>
         </operation>
         <operation name="checkCurrentUserHasBrowseMessagesInDLCPermission">
@@ -182,5 +182,12 @@
         <operation name="getTotalSubscriptionCountForSearchResult">
             <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/subscriptions/queue-browse,/permission/admin/manage/subscriptions/topic-browse</parameter>
         </operation>
+        <operation name="getMessageMetadataInDeadLetterChannel">
+            <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/dlc/browse,/permission/admin/manage/dlc/delete,/permission/admin/manage/dlc/restore,/permission/admin/manage/dlc/reroute</parameter>
+        </operation>
+        <operation name="rerouteAllMessagesFromDeadLetterChannelForQueue">
+            <parameter name="AuthorizationAction" locked="false">/permission/admin/manage/dlc/browse,/permission/admin/manage/dlc/delete,/permission/admin/manage/dlc/restore,/permission/admin/manage/dlc/reroute</parameter>
+        </operation>
+
     </service>
 </serviceGroup>

--- a/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/QueueManagerService.java
+++ b/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/QueueManagerService.java
@@ -93,7 +93,7 @@ public interface QueueManagerService {
      * @return unavailable message count
      * @throws QueueManagerException
      */
-    public long restoreMessagesFromDeadLetterQueue(long[] messageIDs, String destinationQueueName)
+    public long restoreSelectedMessagesFromDeadLetterChannel(long[] messageIDs, String destinationQueueName)
             throws QueueManagerException;
 
     /**
@@ -105,7 +105,7 @@ public interface QueueManagerService {
      * @return unavailable message count
      * @throws QueueManagerException
      */
-    public long restoreMessagesFromDeadLetterQueueWithDifferentDestination(long[] messageIDs,
+    public long rerouteSelectedMessagesFromDeadLetterChannel(long[] messageIDs,
                                                                            String newDestinationQueueName,
                                                                            String destinationQueueName)
             throws QueueManagerException;
@@ -240,14 +240,41 @@ public interface QueueManagerService {
      * @param nextMessageIdToRead next start message id to get message list
      * @param maxMessageCount     the maximum messages to return
      * @return an array of messages
-     * @throws QueueManagerException
+     * @throws QueueManagerException if an exception occurs when invoking the MBean Service.
      */
-    Message[] getMessageInDLCForQueue(String queueName,
-                                      long nextMessageIdToRead, int maxMessageCount)
+    Message[] getMessagesInDLCForQueue(String queueName,
+                                       long nextMessageIdToRead, int maxMessageCount)
             throws QueueManagerException;
 
     /**
      * Dump message status to a default file. This is used for troubleshooting
      */
     void dumpMessageStatus() throws AndesException;
+
+
+    /**
+     * Returns a paginated list of message metadata destined for the inputQueueName but currently living in the Dead Letter Channel.
+     *
+     * @param targetQueue    Name of the destination queue
+     * @param startMessageId Start point of the queue message id to start reading
+     * @param pageLimit      Maximum messages required in a single response
+     * @return Array of {@link org.wso2.carbon.andes.admin.internal.Message}
+     * @throws QueueManagerException if an error occurs while invoking the MBean to fetch messages.
+     */
+    Message[] getMessageMetadataInDLC(String targetQueue, long startMessageId, int pageLimit)
+            throws QueueManagerException;
+
+    /**
+     * Restore messages destined for the input sourceQueue into a different targetQueue.
+     * If the sourceQueue is DLCQueue, all messages in the DLC will be restored to the targetQueue.
+     *
+     * @param sourceQueue Name of the source queue
+     * @param targetQueue Name of the target queue.
+     * @param internalBatchSize even with this method, the MB server will internally read messages in DLC in batches,
+     *                          and simulate each batch as a new message list to the targetQueue. internalBatchSize
+     *                          controls the number of messages processed in a single batch internally.
+     * @throws QueueManagerException if an exception occurs while invoking the MBean service.
+     */
+    int rerouteMessagesFromDeadLetterChannelForQueue(String sourceQueue, String targetQueue, int internalBatchSize) throws
+            QueueManagerException;
 }

--- a/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/internal/registry/QueueManagementBeans.java
+++ b/components/andes/org.wso2.carbon.andes.core/src/main/java/org/wso2/carbon/andes/core/internal/registry/QueueManagementBeans.java
@@ -274,7 +274,7 @@ public class QueueManagementBeans {
      * @return unavailable message count
      * @throws QueueManagerException
      */
-    public long restoreMessagesFromDeadLetterQueue(long[] messageIDs, String destinationQueueName) throws
+    public long restoreSelectedMessagesFromDeadLetterChannel(long[] messageIDs, String destinationQueueName) throws
             QueueManagerException {
         long unavailableMessageCount = 0L;
         MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -282,7 +282,7 @@ public class QueueManagementBeans {
             ObjectName objectName =
                     new ObjectName("org.wso2.andes:type=QueueManagementInformation,name=QueueManagementInformation");
 
-            String operationName = "restoreMessagesFromDeadLetterQueue";
+            String operationName = "restoreSelectedMessagesFromDeadLetterChannel";
             Object[] parameters = new Object[]{messageIDs, destinationQueueName};
             String[] signature = new String[]{long[].class.getName(), String.class.getName()};
             Object result = mBeanServer.invoke(
@@ -309,7 +309,7 @@ public class QueueManagementBeans {
      * @return unavailable message count
      * @throws QueueManagerException
      */
-    public long restoreMessagesFromDeadLetterQueueWithDifferentDestination(long[] messageIDs,
+    public long rerouteSelectedMessagesFromDeadLetterChannel(long[] messageIDs,
             String newDestinationQueueName, String destinationQueueName) throws QueueManagerException {
         long unavailableMessageCount = 0L;
         MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -317,8 +317,8 @@ public class QueueManagementBeans {
             ObjectName objectName =
                     new ObjectName("org.wso2.andes:type=QueueManagementInformation,name=QueueManagementInformation");
 
-            String operationName = "restoreMessagesFromDeadLetterQueue";
-            Object[] parameters = new Object[]{messageIDs, newDestinationQueueName, destinationQueueName};
+            String operationName = "rerouteSelectedMessagesFromDeadLetterChannel";
+            Object[] parameters = new Object[]{messageIDs, destinationQueueName, newDestinationQueueName };
             String[] signature = new String[]{long[].class.getName(), String.class.getName(), String.class.getName()};
             Object result = mBeanServer.invoke(
                     objectName,

--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/AndesAdminService.wsdl
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/AndesAdminService.wsdl
@@ -1,4 +1,4 @@
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:ns="http://wso2.org/carbon/andes/admin/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:tns="http://wso2.org/carbon/andes/admin" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:ax23="http://internal.admin.andes.carbon.wso2.org/xsd" xmlns:ax21="http://Exception.internal.admin.andes.carbon.wso2.org/xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" targetNamespace="http://wso2.org/carbon/andes/admin">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax23="http://internal.admin.andes.carbon.wso2.org/xsd" xmlns:ns="http://wso2.org/carbon/andes/admin/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://wso2.org/carbon/andes/admin" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ax21="http://Exception.internal.admin.andes.carbon.wso2.org/xsd" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://wso2.org/carbon/andes/admin">
     <wsdl:documentation>AndesAdminService</wsdl:documentation>
     <wsdl:types>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://Exception.internal.admin.andes.carbon.wso2.org/xsd">
@@ -9,19 +9,6 @@
             </xs:complexType>
         </xs:schema>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://internal.admin.andes.carbon.wso2.org/xsd">
-            <xs:complexType name="Subscription">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="active" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="destination" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="durable" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="numberOfMessagesRemainingForSubscriber" type="xs:int"/>
-                    <xs:element minOccurs="0" name="subscribedQueueOrTopicName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="connectedNodeAddress" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="subscriberQueueBoundExchange" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="subscriberQueueName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="subscriptionIdentifier" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
             <xs:complexType name="Queue">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="createdFrom" nillable="true" type="xs:string"/>
@@ -32,11 +19,20 @@
                     <xs:element minOccurs="0" name="updatedTime" nillable="true" type="xs:dateTime"/>
                 </xs:sequence>
             </xs:complexType>
-            <xs:complexType name="QueueRolePermission">
+            <xs:complexType name="Subscription">
                 <xs:sequence>
-                    <xs:element minOccurs="0" name="allowedToConsume" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="allowedToPublish" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="roleName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="active" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="connectedNodeAddress" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="destination" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="durable" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="numberOfMessagesRemainingForSubscriber" type="xs:int"/>
+                    <xs:element minOccurs="0" name="originHostAddress" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="subscribedQueueOrTopicName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="subscriberQueueBoundExchange" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="subscriberQueueName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="subscriptionIdentifier" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
             <xs:complexType name="Message">
@@ -56,6 +52,13 @@
                     <xs:element minOccurs="0" name="msgProperties" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
+            <xs:complexType name="QueueRolePermission">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="allowedToConsume" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="allowedToPublish" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="roleName" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
         </xs:schema>
         <xs:schema xmlns:ax22="http://Exception.internal.admin.andes.carbon.wso2.org/xsd" xmlns:ax24="http://internal.admin.andes.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://wso2.org/carbon/andes/admin/xsd">
             <xs:import namespace="http://Exception.internal.admin.andes.carbon.wso2.org/xsd"/>
@@ -63,83 +66,29 @@
             <xs:element name="AndesAdminServiceBrokerManagerAdminException">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="BrokerManagerAdminException" nillable="true" type="ax21:BrokerManagerAdminException"/>
+                        <xs:element minOccurs="0" name="BrokerManagerAdminException" nillable="true" type="ax22:BrokerManagerAdminException"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getAllDurableQueueSubscriptions">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllDurableQueueSubscriptionsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Subscription"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllLocalTempQueueSubscriptions">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllLocalTempQueueSubscriptionsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Subscription"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllDurableTopicSubscriptions">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllDurableTopicSubscriptionsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Subscription"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deleteQueue">
+            <xs:element name="getQueueByName">
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="deleteTopicFromRegistry">
+            <xs:element name="getQueueByNameResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="topicName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="subscriptionId" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="restoreMessagesFromDeadLetterQueue">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="messageIDs" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="deadLetterQueueName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="restoreMessagesFromDeadLetterQueueWithDifferentDestination">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="messageIDs" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="destination" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="deadLetterQueueName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax24:Queue"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element name="deleteMessagesFromDeadLetterQueue">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="messageIDs" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="deadLetterQueueName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="messageIDs" type="xs:long"/>
+                        <xs:element minOccurs="0" name="destinationQueueName" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -147,6 +96,18 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="closeSubscription">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="isDurable" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="subscriptionID" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="subscribedQueueOrTopicName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="subscriberQueueName" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -158,53 +119,441 @@
             <xs:element name="getAllSubscriptionsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Subscription"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Subscription"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getAllQueues">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllQueuesResponse">
+            <xs:element name="getSubscriptions">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Queue"/>
+                        <xs:element minOccurs="0" name="isDurable" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="isActive" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getMessageCount">
+            <xs:element name="getSubscriptionsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="destinationName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="msgPattern" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Subscription"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getMessageCountResponse">
+            <xs:element name="getFilteredSubscriptions">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                        <xs:element minOccurs="0" name="isDurable" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="isActive" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="filteredNamePattern" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="isFilteredNameByExactMatch" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="identifierPattern" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="isIdentifierPatternByExactMatch" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="ownNodeId" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="pageNumber" type="xs:int"/>
+                        <xs:element minOccurs="0" name="subscriptionCountPerPage" type="xs:int"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="createQueue">
+            <xs:element name="getFilteredSubscriptionsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Subscription"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageCountForSubscriber">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="subscriptionID" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="durable" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageCountForSubscriberResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getPendingMessageCount">
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getAllLocalTempTopicSubscriptions">
+            <xs:element name="getPendingMessageCountResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="dumpMessageStatus">
                 <xs:complexType>
                     <xs:sequence/>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getAllLocalTempTopicSubscriptionsResponse">
+            <xs:element name="checkCurrentUserHasPublishPermission">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Subscription"/>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasPublishPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasPublishPermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="userName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasPublishPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasAddQueuePermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasAddQueuePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasAddQueuePermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasAddQueuePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasBrowseQueuePermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasBrowseQueuePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasBrowseQueuePermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasBrowseQueuePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasDeleteQueuePermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasDeleteQueuePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasDeleteQueuePermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasDeleteQueuePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasPurgeQueuePermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasPurgeQueuePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasPurgeQueuePermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasPurgeQueuePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasBrowseMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasBrowseMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasBrowseMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasBrowseMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasDeleteMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasDeleteMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasDeleteMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasDeleteMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasRestoreMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasRestoreMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasRestoreMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasRestoreMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasRerouteMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasRerouteMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasRerouteMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasRerouteMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasQueueSubscriptionClosePermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasQueueSubscriptionClosePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasTopicSubscriptionClosePermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasTopicSubscriptionClosePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageMetadataInDeadLetterChannel">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="targetQueue" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="startMessageId" type="xs:long"/>
+                        <xs:element minOccurs="0" name="pageLimit" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageMetadataInDeadLetterChannelResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Message"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="rerouteAllMessagesFromDeadLetterChannelForQueue">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="sourceQueue" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="targetQueue" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="internalBatchSize" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="rerouteAllMessagesFromDeadLetterChannelForQueueResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getDLCQueue">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getDLCQueueResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax24:Queue"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getTotalSubscriptionCountForSearchResult">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="isDurable" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="isActive" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="filteredNamePattern" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="isFilteredNameByExactMatch" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="identifierPattern" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="isIdentifierPatternByExactMatch" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="ownNodeId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getTotalSubscriptionCountForSearchResultResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getNumberOfMessagesInDLCForQueue">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getNumberOfMessagesInDLCForQueueResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessagesInDLCForQueue">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="nextMessageIdToRead" type="xs:long"/>
+                        <xs:element minOccurs="0" name="maxMsgCount" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessagesInDLCForQueueResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Message"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -212,7 +561,15 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="queueRolePermissionsDTO" nillable="true" type="ax23:QueueRolePermission"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="queueRolePermissionsDTO" nillable="true" type="ax24:QueueRolePermission"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="addQueueAndAssignPermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="queueRolePermissionsDTO" nillable="true" type="ax24:QueueRolePermission"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -238,7 +595,7 @@
             <xs:element name="getQueueRolePermissionResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:QueueRolePermission"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:QueueRolePermission"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -254,7 +611,7 @@
             <xs:element name="browseQueueResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Message"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Message"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -272,18 +629,88 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getMessageCountForSubscriber">
+            <xs:element name="getAllQueues">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllQueuesResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="subscriptionID" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="durable" type="xs:boolean"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Queue"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getMessageCountForSubscriberResponse">
+            <xs:element name="getNamesOfAllDurableQueues">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getNamesOfAllDurableQueuesResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:int"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageCount">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="destinationName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="msgPattern" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageCountResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteQueue">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteTopicFromRegistry">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="topicName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="subscriptionId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="restoreSelectedMessagesFromDeadLetterChannel">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="messageIDs" type="xs:long"/>
+                        <xs:element minOccurs="0" name="destinationQueueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="restoreSelectedMessagesFromDeadLetterChannelResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="rerouteSelectedMessagesFromDeadLetterChannel">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="messageIDs" type="xs:long"/>
+                        <xs:element minOccurs="0" name="newDestinationQueueName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="destinationQueueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="rerouteSelectedMessagesFromDeadLetterChannelResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:long"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -308,116 +735,16 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getAccessKey">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAccessKeyResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
         </xs:schema>
     </wsdl:types>
-    <wsdl:message name="getAllDurableTopicSubscriptionsRequest">
-        <wsdl:part name="parameters" element="ns:getAllDurableTopicSubscriptions"/>
+    <wsdl:message name="checkUserHasBrowseMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasBrowseMessagesInDLCPermission"/>
     </wsdl:message>
-    <wsdl:message name="getAllDurableTopicSubscriptionsResponse">
-        <wsdl:part name="parameters" element="ns:getAllDurableTopicSubscriptionsResponse"/>
+    <wsdl:message name="checkUserHasBrowseMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasBrowseMessagesInDLCPermissionResponse"/>
     </wsdl:message>
     <wsdl:message name="AndesAdminServiceBrokerManagerAdminException">
         <wsdl:part name="parameters" element="ns:AndesAdminServiceBrokerManagerAdminException"/>
-    </wsdl:message>
-    <wsdl:message name="deleteMessagesFromDeadLetterQueueRequest">
-        <wsdl:part name="parameters" element="ns:deleteMessagesFromDeadLetterQueue"/>
-    </wsdl:message>
-    <wsdl:message name="deleteMessagesFromDeadLetterQueueResponse"/>
-    <wsdl:message name="getAccessKeyRequest">
-        <wsdl:part name="parameters" element="ns:getAccessKey"/>
-    </wsdl:message>
-    <wsdl:message name="getAccessKeyResponse">
-        <wsdl:part name="parameters" element="ns:getAccessKeyResponse"/>
-    </wsdl:message>
-    <wsdl:message name="getAllQueuesRequest">
-        <wsdl:part name="parameters" element="ns:getAllQueues"/>
-    </wsdl:message>
-    <wsdl:message name="getAllQueuesResponse">
-        <wsdl:part name="parameters" element="ns:getAllQueuesResponse"/>
-    </wsdl:message>
-    <wsdl:message name="getAllLocalTempQueueSubscriptionsRequest">
-        <wsdl:part name="parameters" element="ns:getAllLocalTempQueueSubscriptions"/>
-    </wsdl:message>
-    <wsdl:message name="getAllLocalTempQueueSubscriptionsResponse">
-        <wsdl:part name="parameters" element="ns:getAllLocalTempQueueSubscriptionsResponse"/>
-    </wsdl:message>
-    <wsdl:message name="getAllDurableQueueSubscriptionsRequest">
-        <wsdl:part name="parameters" element="ns:getAllDurableQueueSubscriptions"/>
-    </wsdl:message>
-    <wsdl:message name="getAllDurableQueueSubscriptionsResponse">
-        <wsdl:part name="parameters" element="ns:getAllDurableQueueSubscriptionsResponse"/>
-    </wsdl:message>
-    <wsdl:message name="updatePermissionRequest">
-        <wsdl:part name="parameters" element="ns:updatePermission"/>
-    </wsdl:message>
-    <wsdl:message name="updatePermissionResponse"/>
-    <wsdl:message name="sendMessageRequest">
-        <wsdl:part name="parameters" element="ns:sendMessage"/>
-    </wsdl:message>
-    <wsdl:message name="sendMessageResponse">
-        <wsdl:part name="parameters" element="ns:sendMessageResponse"/>
-    </wsdl:message>
-    <wsdl:message name="createQueueRequest">
-        <wsdl:part name="parameters" element="ns:createQueue"/>
-    </wsdl:message>
-    <wsdl:message name="createQueueResponse"/>
-    <wsdl:message name="deleteTopicFromRegistryRequest">
-        <wsdl:part name="parameters" element="ns:deleteTopicFromRegistry"/>
-    </wsdl:message>
-    <wsdl:message name="deleteTopicFromRegistryResponse"/>
-    <wsdl:message name="restoreMessagesFromDeadLetterQueueRequest">
-        <wsdl:part name="parameters" element="ns:restoreMessagesFromDeadLetterQueue"/>
-    </wsdl:message>
-    <wsdl:message name="restoreMessagesFromDeadLetterQueueResponse"/>
-    <wsdl:message name="purgeMessagesOfQueueRequest">
-        <wsdl:part name="parameters" element="ns:purgeMessagesOfQueue"/>
-    </wsdl:message>
-    <wsdl:message name="purgeMessagesOfQueueResponse"/>
-    <wsdl:message name="getMessageCountForSubscriberRequest">
-        <wsdl:part name="parameters" element="ns:getMessageCountForSubscriber"/>
-    </wsdl:message>
-    <wsdl:message name="getMessageCountForSubscriberResponse">
-        <wsdl:part name="parameters" element="ns:getMessageCountForSubscriberResponse"/>
-    </wsdl:message>
-    <wsdl:message name="browseQueueRequest">
-        <wsdl:part name="parameters" element="ns:browseQueue"/>
-    </wsdl:message>
-    <wsdl:message name="browseQueueResponse">
-        <wsdl:part name="parameters" element="ns:browseQueueResponse"/>
-    </wsdl:message>
-    <wsdl:message name="getTotalMessagesInQueueRequest">
-        <wsdl:part name="parameters" element="ns:getTotalMessagesInQueue"/>
-    </wsdl:message>
-    <wsdl:message name="getTotalMessagesInQueueResponse">
-        <wsdl:part name="parameters" element="ns:getTotalMessagesInQueueResponse"/>
-    </wsdl:message>
-    <wsdl:message name="deleteQueueRequest">
-        <wsdl:part name="parameters" element="ns:deleteQueue"/>
-    </wsdl:message>
-    <wsdl:message name="deleteQueueResponse"/>
-    <wsdl:message name="getAllLocalTempTopicSubscriptionsRequest">
-        <wsdl:part name="parameters" element="ns:getAllLocalTempTopicSubscriptions"/>
-    </wsdl:message>
-    <wsdl:message name="getAllLocalTempTopicSubscriptionsResponse">
-        <wsdl:part name="parameters" element="ns:getAllLocalTempTopicSubscriptionsResponse"/>
-    </wsdl:message>
-    <wsdl:message name="getQueueRolePermissionRequest">
-        <wsdl:part name="parameters" element="ns:getQueueRolePermission"/>
-    </wsdl:message>
-    <wsdl:message name="getQueueRolePermissionResponse">
-        <wsdl:part name="parameters" element="ns:getQueueRolePermissionResponse"/>
     </wsdl:message>
     <wsdl:message name="getMessageCountRequest">
         <wsdl:part name="parameters" element="ns:getMessageCount"/>
@@ -425,11 +752,57 @@
     <wsdl:message name="getMessageCountResponse">
         <wsdl:part name="parameters" element="ns:getMessageCountResponse"/>
     </wsdl:message>
+    <wsdl:message name="getMessagesInDLCForQueueRequest">
+        <wsdl:part name="parameters" element="ns:getMessagesInDLCForQueue"/>
+    </wsdl:message>
+    <wsdl:message name="getMessagesInDLCForQueueResponse">
+        <wsdl:part name="parameters" element="ns:getMessagesInDLCForQueueResponse"/>
+    </wsdl:message>
+    <wsdl:message name="dumpMessageStatusRequest">
+        <wsdl:part name="parameters" element="ns:dumpMessageStatus"/>
+    </wsdl:message>
+    <wsdl:message name="dumpMessageStatusResponse"/>
     <wsdl:message name="getUserRolesRequest">
         <wsdl:part name="parameters" element="ns:getUserRoles"/>
     </wsdl:message>
     <wsdl:message name="getUserRolesResponse">
         <wsdl:part name="parameters" element="ns:getUserRolesResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasBrowseQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasBrowseQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseQueuePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="rerouteAllMessagesFromDeadLetterChannelForQueueRequest">
+        <wsdl:part name="parameters" element="ns:rerouteAllMessagesFromDeadLetterChannelForQueue"/>
+    </wsdl:message>
+    <wsdl:message name="rerouteAllMessagesFromDeadLetterChannelForQueueResponse">
+        <wsdl:part name="parameters" element="ns:rerouteAllMessagesFromDeadLetterChannelForQueueResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getPendingMessageCountRequest">
+        <wsdl:part name="parameters" element="ns:getPendingMessageCount"/>
+    </wsdl:message>
+    <wsdl:message name="getPendingMessageCountResponse">
+        <wsdl:part name="parameters" element="ns:getPendingMessageCountResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getSubscriptionsRequest">
+        <wsdl:part name="parameters" element="ns:getSubscriptions"/>
+    </wsdl:message>
+    <wsdl:message name="getSubscriptionsResponse">
+        <wsdl:part name="parameters" element="ns:getSubscriptionsResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasDeleteMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasDeleteMessagesInDLCPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasDeleteMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasDeleteMessagesInDLCPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasRerouteMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasRerouteMessagesInDLCPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasRerouteMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasRerouteMessagesInDLCPermissionResponse"/>
     </wsdl:message>
     <wsdl:message name="getAllSubscriptionsRequest">
         <wsdl:part name="parameters" element="ns:getAllSubscriptions"/>
@@ -437,338 +810,476 @@
     <wsdl:message name="getAllSubscriptionsResponse">
         <wsdl:part name="parameters" element="ns:getAllSubscriptionsResponse"/>
     </wsdl:message>
-    <wsdl:message name="restoreMessagesFromDeadLetterQueueWithDifferentDestinationRequest">
-        <wsdl:part name="parameters" element="ns:restoreMessagesFromDeadLetterQueueWithDifferentDestination"/>
+    <wsdl:message name="getAllQueuesRequest">
+        <wsdl:part name="parameters" element="ns:getAllQueues"/>
     </wsdl:message>
-    <wsdl:message name="restoreMessagesFromDeadLetterQueueWithDifferentDestinationResponse"/>
+    <wsdl:message name="getAllQueuesResponse">
+        <wsdl:part name="parameters" element="ns:getAllQueuesResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasDeleteQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasDeleteQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasDeleteQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasDeleteQueuePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageMetadataInDeadLetterChannelRequest">
+        <wsdl:part name="parameters" element="ns:getMessageMetadataInDeadLetterChannel"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageMetadataInDeadLetterChannelResponse">
+        <wsdl:part name="parameters" element="ns:getMessageMetadataInDeadLetterChannelResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getTotalMessagesInQueueRequest">
+        <wsdl:part name="parameters" element="ns:getTotalMessagesInQueue"/>
+    </wsdl:message>
+    <wsdl:message name="getTotalMessagesInQueueResponse">
+        <wsdl:part name="parameters" element="ns:getTotalMessagesInQueueResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageCountForSubscriberRequest">
+        <wsdl:part name="parameters" element="ns:getMessageCountForSubscriber"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageCountForSubscriberResponse">
+        <wsdl:part name="parameters" element="ns:getMessageCountForSubscriberResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getNamesOfAllDurableQueuesRequest">
+        <wsdl:part name="parameters" element="ns:getNamesOfAllDurableQueues"/>
+    </wsdl:message>
+    <wsdl:message name="getNamesOfAllDurableQueuesResponse">
+        <wsdl:part name="parameters" element="ns:getNamesOfAllDurableQueuesResponse"/>
+    </wsdl:message>
+    <wsdl:message name="addQueueAndAssignPermissionRequest">
+        <wsdl:part name="parameters" element="ns:addQueueAndAssignPermission"/>
+    </wsdl:message>
+    <wsdl:message name="addQueueAndAssignPermissionResponse"/>
+    <wsdl:message name="browseQueueRequest">
+        <wsdl:part name="parameters" element="ns:browseQueue"/>
+    </wsdl:message>
+    <wsdl:message name="browseQueueResponse">
+        <wsdl:part name="parameters" element="ns:browseQueueResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getTotalSubscriptionCountForSearchResultRequest">
+        <wsdl:part name="parameters" element="ns:getTotalSubscriptionCountForSearchResult"/>
+    </wsdl:message>
+    <wsdl:message name="getTotalSubscriptionCountForSearchResultResponse">
+        <wsdl:part name="parameters" element="ns:getTotalSubscriptionCountForSearchResultResponse"/>
+    </wsdl:message>
+    <wsdl:message name="purgeMessagesOfQueueRequest">
+        <wsdl:part name="parameters" element="ns:purgeMessagesOfQueue"/>
+    </wsdl:message>
+    <wsdl:message name="purgeMessagesOfQueueResponse"/>
+    <wsdl:message name="checkUserHasPurgeQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasPurgeQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasPurgeQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasPurgeQueuePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasQueueSubscriptionClosePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasQueueSubscriptionClosePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasQueueSubscriptionClosePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasQueueSubscriptionClosePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasRestoreMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasRestoreMessagesInDLCPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasRestoreMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasRestoreMessagesInDLCPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasAddQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasAddQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasAddQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasAddQueuePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getQueueByNameRequest">
+        <wsdl:part name="parameters" element="ns:getQueueByName"/>
+    </wsdl:message>
+    <wsdl:message name="getQueueByNameResponse">
+        <wsdl:part name="parameters" element="ns:getQueueByNameResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasBrowseQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasBrowseQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasBrowseQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasBrowseQueuePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasPublishPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPublishPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasPublishPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPublishPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasPurgeQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPurgeQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasPurgeQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPurgeQueuePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getDLCQueueRequest">
+        <wsdl:part name="parameters" element="ns:getDLCQueue"/>
+    </wsdl:message>
+    <wsdl:message name="getDLCQueueResponse">
+        <wsdl:part name="parameters" element="ns:getDLCQueueResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasDeleteMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasDeleteMessagesInDLCPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasDeleteMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasDeleteMessagesInDLCPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getNumberOfMessagesInDLCForQueueRequest">
+        <wsdl:part name="parameters" element="ns:getNumberOfMessagesInDLCForQueue"/>
+    </wsdl:message>
+    <wsdl:message name="getNumberOfMessagesInDLCForQueueResponse">
+        <wsdl:part name="parameters" element="ns:getNumberOfMessagesInDLCForQueueResponse"/>
+    </wsdl:message>
+    <wsdl:message name="rerouteSelectedMessagesFromDeadLetterChannelRequest">
+        <wsdl:part name="parameters" element="ns:rerouteSelectedMessagesFromDeadLetterChannel"/>
+    </wsdl:message>
+    <wsdl:message name="rerouteSelectedMessagesFromDeadLetterChannelResponse">
+        <wsdl:part name="parameters" element="ns:rerouteSelectedMessagesFromDeadLetterChannelResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasRerouteMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRerouteMessagesInDLCPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasRerouteMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRerouteMessagesInDLCPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="restoreSelectedMessagesFromDeadLetterChannelRequest">
+        <wsdl:part name="parameters" element="ns:restoreSelectedMessagesFromDeadLetterChannel"/>
+    </wsdl:message>
+    <wsdl:message name="restoreSelectedMessagesFromDeadLetterChannelResponse">
+        <wsdl:part name="parameters" element="ns:restoreSelectedMessagesFromDeadLetterChannelResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getFilteredSubscriptionsRequest">
+        <wsdl:part name="parameters" element="ns:getFilteredSubscriptions"/>
+    </wsdl:message>
+    <wsdl:message name="getFilteredSubscriptionsResponse">
+        <wsdl:part name="parameters" element="ns:getFilteredSubscriptionsResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasRestoreMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRestoreMessagesInDLCPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasRestoreMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRestoreMessagesInDLCPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="updatePermissionRequest">
+        <wsdl:part name="parameters" element="ns:updatePermission"/>
+    </wsdl:message>
+    <wsdl:message name="updatePermissionResponse"/>
+    <wsdl:message name="checkUserHasPublishPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasPublishPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasPublishPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasPublishPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasBrowseMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseMessagesInDLCPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasBrowseMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseMessagesInDLCPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="closeSubscriptionRequest">
+        <wsdl:part name="parameters" element="ns:closeSubscription"/>
+    </wsdl:message>
+    <wsdl:message name="closeSubscriptionResponse"/>
+    <wsdl:message name="sendMessageRequest">
+        <wsdl:part name="parameters" element="ns:sendMessage"/>
+    </wsdl:message>
+    <wsdl:message name="sendMessageResponse">
+        <wsdl:part name="parameters" element="ns:sendMessageResponse"/>
+    </wsdl:message>
+    <wsdl:message name="deleteMessagesFromDeadLetterQueueRequest">
+        <wsdl:part name="parameters" element="ns:deleteMessagesFromDeadLetterQueue"/>
+    </wsdl:message>
+    <wsdl:message name="deleteMessagesFromDeadLetterQueueResponse"/>
+    <wsdl:message name="deleteTopicFromRegistryRequest">
+        <wsdl:part name="parameters" element="ns:deleteTopicFromRegistry"/>
+    </wsdl:message>
+    <wsdl:message name="deleteTopicFromRegistryResponse"/>
+    <wsdl:message name="checkCurrentUserHasDeleteQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasDeleteQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasDeleteQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasDeleteQueuePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getQueueRolePermissionRequest">
+        <wsdl:part name="parameters" element="ns:getQueueRolePermission"/>
+    </wsdl:message>
+    <wsdl:message name="getQueueRolePermissionResponse">
+        <wsdl:part name="parameters" element="ns:getQueueRolePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasAddQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasAddQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasAddQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasAddQueuePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="deleteQueueRequest">
+        <wsdl:part name="parameters" element="ns:deleteQueue"/>
+    </wsdl:message>
+    <wsdl:message name="deleteQueueResponse"/>
+    <wsdl:message name="checkCurrentUserHasTopicSubscriptionClosePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasTopicSubscriptionClosePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasTopicSubscriptionClosePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasTopicSubscriptionClosePermissionResponse"/>
+    </wsdl:message>
     <wsdl:portType name="AndesAdminServicePortType">
-        <wsdl:operation name="getAllDurableTopicSubscriptions">
-            <wsdl:input message="tns:getAllDurableTopicSubscriptionsRequest" wsaw:Action="urn:getAllDurableTopicSubscriptions"/>
-            <wsdl:output message="tns:getAllDurableTopicSubscriptionsResponse" wsaw:Action="urn:getAllDurableTopicSubscriptionsResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getAllDurableTopicSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
-            <wsdl:input message="tns:deleteMessagesFromDeadLetterQueueRequest" wsaw:Action="urn:deleteMessagesFromDeadLetterQueue"/>
-            <wsdl:output message="tns:deleteMessagesFromDeadLetterQueueResponse" wsaw:Action="urn:deleteMessagesFromDeadLetterQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteMessagesFromDeadLetterQueueAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getAccessKey">
-            <wsdl:input message="tns:getAccessKeyRequest" wsaw:Action="urn:getAccessKey"/>
-            <wsdl:output message="tns:getAccessKeyResponse" wsaw:Action="urn:getAccessKeyResponse"/>
-        </wsdl:operation>
-        <wsdl:operation name="getAllQueues">
-            <wsdl:input message="tns:getAllQueuesRequest" wsaw:Action="urn:getAllQueues"/>
-            <wsdl:output message="tns:getAllQueuesResponse" wsaw:Action="urn:getAllQueuesResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getAllQueuesAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getAllLocalTempQueueSubscriptions">
-            <wsdl:input message="tns:getAllLocalTempQueueSubscriptionsRequest" wsaw:Action="urn:getAllLocalTempQueueSubscriptions"/>
-            <wsdl:output message="tns:getAllLocalTempQueueSubscriptionsResponse" wsaw:Action="urn:getAllLocalTempQueueSubscriptionsResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getAllLocalTempQueueSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getAllDurableQueueSubscriptions">
-            <wsdl:input message="tns:getAllDurableQueueSubscriptionsRequest" wsaw:Action="urn:getAllDurableQueueSubscriptions"/>
-            <wsdl:output message="tns:getAllDurableQueueSubscriptionsResponse" wsaw:Action="urn:getAllDurableQueueSubscriptionsResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getAllDurableQueueSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="updatePermission">
-            <wsdl:input message="tns:updatePermissionRequest" wsaw:Action="urn:updatePermission"/>
-            <wsdl:output message="tns:updatePermissionResponse" wsaw:Action="urn:updatePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:updatePermissionAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="sendMessage">
-            <wsdl:input message="tns:sendMessageRequest" wsaw:Action="urn:sendMessage"/>
-            <wsdl:output message="tns:sendMessageResponse" wsaw:Action="urn:sendMessageResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:sendMessageAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="createQueue">
-            <wsdl:input message="tns:createQueueRequest" wsaw:Action="urn:createQueue"/>
-            <wsdl:output message="tns:createQueueResponse" wsaw:Action="urn:createQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:createQueueAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="deleteTopicFromRegistry">
-            <wsdl:input message="tns:deleteTopicFromRegistryRequest" wsaw:Action="urn:deleteTopicFromRegistry"/>
-            <wsdl:output message="tns:deleteTopicFromRegistryResponse" wsaw:Action="urn:deleteTopicFromRegistryResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteTopicFromRegistryAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueue">
-            <wsdl:input message="tns:restoreMessagesFromDeadLetterQueueRequest" wsaw:Action="urn:restoreMessagesFromDeadLetterQueue"/>
-            <wsdl:output message="tns:restoreMessagesFromDeadLetterQueueResponse" wsaw:Action="urn:restoreMessagesFromDeadLetterQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:restoreMessagesFromDeadLetterQueueAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="purgeMessagesOfQueue">
-            <wsdl:input message="tns:purgeMessagesOfQueueRequest" wsaw:Action="urn:purgeMessagesOfQueue"/>
-            <wsdl:output message="tns:purgeMessagesOfQueueResponse" wsaw:Action="urn:purgeMessagesOfQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:purgeMessagesOfQueueAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageCountForSubscriber">
-            <wsdl:input message="tns:getMessageCountForSubscriberRequest" wsaw:Action="urn:getMessageCountForSubscriber"/>
-            <wsdl:output message="tns:getMessageCountForSubscriberResponse" wsaw:Action="urn:getMessageCountForSubscriberResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getMessageCountForSubscriberAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="browseQueue">
-            <wsdl:input message="tns:browseQueueRequest" wsaw:Action="urn:browseQueue"/>
-            <wsdl:output message="tns:browseQueueResponse" wsaw:Action="urn:browseQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:browseQueueAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getTotalMessagesInQueue">
-            <wsdl:input message="tns:getTotalMessagesInQueueRequest" wsaw:Action="urn:getTotalMessagesInQueue"/>
-            <wsdl:output message="tns:getTotalMessagesInQueueResponse" wsaw:Action="urn:getTotalMessagesInQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getTotalMessagesInQueueAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="deleteQueue">
-            <wsdl:input message="tns:deleteQueueRequest" wsaw:Action="urn:deleteQueue"/>
-            <wsdl:output message="tns:deleteQueueResponse" wsaw:Action="urn:deleteQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteQueueAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getAllLocalTempTopicSubscriptions">
-            <wsdl:input message="tns:getAllLocalTempTopicSubscriptionsRequest" wsaw:Action="urn:getAllLocalTempTopicSubscriptions"/>
-            <wsdl:output message="tns:getAllLocalTempTopicSubscriptionsResponse" wsaw:Action="urn:getAllLocalTempTopicSubscriptionsResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getAllLocalTempTopicSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getQueueRolePermission">
-            <wsdl:input message="tns:getQueueRolePermissionRequest" wsaw:Action="urn:getQueueRolePermission"/>
-            <wsdl:output message="tns:getQueueRolePermissionResponse" wsaw:Action="urn:getQueueRolePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getQueueRolePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
+            <wsdl:input message="tns:checkUserHasBrowseMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasBrowseMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkUserHasBrowseMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasBrowseMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasBrowseMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
         <wsdl:operation name="getMessageCount">
             <wsdl:input message="tns:getMessageCountRequest" wsaw:Action="urn:getMessageCount"/>
             <wsdl:output message="tns:getMessageCountResponse" wsaw:Action="urn:getMessageCountResponse"/>
             <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getMessageCountAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
+        <wsdl:operation name="getMessagesInDLCForQueue">
+            <wsdl:input message="tns:getMessagesInDLCForQueueRequest" wsaw:Action="urn:getMessagesInDLCForQueue"/>
+            <wsdl:output message="tns:getMessagesInDLCForQueueResponse" wsaw:Action="urn:getMessagesInDLCForQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getMessagesInDLCForQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="dumpMessageStatus">
+            <wsdl:input message="tns:dumpMessageStatusRequest" wsaw:Action="urn:dumpMessageStatus"/>
+            <wsdl:output message="tns:dumpMessageStatusResponse" wsaw:Action="urn:dumpMessageStatusResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:dumpMessageStatusAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
         <wsdl:operation name="getUserRoles">
             <wsdl:input message="tns:getUserRolesRequest" wsaw:Action="urn:getUserRoles"/>
             <wsdl:output message="tns:getUserRolesResponse" wsaw:Action="urn:getUserRolesResponse"/>
             <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getUserRolesAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
+            <wsdl:input message="tns:checkCurrentUserHasBrowseQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasBrowseQueuePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasBrowseQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasBrowseQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasBrowseQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="rerouteAllMessagesFromDeadLetterChannelForQueue">
+            <wsdl:input message="tns:rerouteAllMessagesFromDeadLetterChannelForQueueRequest" wsaw:Action="urn:rerouteAllMessagesFromDeadLetterChannelForQueue"/>
+            <wsdl:output message="tns:rerouteAllMessagesFromDeadLetterChannelForQueueResponse" wsaw:Action="urn:rerouteAllMessagesFromDeadLetterChannelForQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:rerouteAllMessagesFromDeadLetterChannelForQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getPendingMessageCount">
+            <wsdl:input message="tns:getPendingMessageCountRequest" wsaw:Action="urn:getPendingMessageCount"/>
+            <wsdl:output message="tns:getPendingMessageCountResponse" wsaw:Action="urn:getPendingMessageCountResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getPendingMessageCountAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getSubscriptions">
+            <wsdl:input message="tns:getSubscriptionsRequest" wsaw:Action="urn:getSubscriptions"/>
+            <wsdl:output message="tns:getSubscriptionsResponse" wsaw:Action="urn:getSubscriptionsResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasDeleteMessagesInDLCPermission">
+            <wsdl:input message="tns:checkCurrentUserHasDeleteMessagesInDLCPermissionRequest" wsaw:Action="urn:checkCurrentUserHasDeleteMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasDeleteMessagesInDLCPermissionResponse" wsaw:Action="urn:checkCurrentUserHasDeleteMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasDeleteMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
+            <wsdl:input message="tns:checkUserHasRerouteMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasRerouteMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkUserHasRerouteMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasRerouteMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasRerouteMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
         <wsdl:operation name="getAllSubscriptions">
             <wsdl:input message="tns:getAllSubscriptionsRequest" wsaw:Action="urn:getAllSubscriptions"/>
             <wsdl:output message="tns:getAllSubscriptionsResponse" wsaw:Action="urn:getAllSubscriptionsResponse"/>
             <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getAllSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueueWithDifferentDestination">
-            <wsdl:input message="tns:restoreMessagesFromDeadLetterQueueWithDifferentDestinationRequest" wsaw:Action="urn:restoreMessagesFromDeadLetterQueueWithDifferentDestination"/>
-            <wsdl:output message="tns:restoreMessagesFromDeadLetterQueueWithDifferentDestinationResponse" wsaw:Action="urn:restoreMessagesFromDeadLetterQueueWithDifferentDestinationResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:restoreMessagesFromDeadLetterQueueWithDifferentDestinationAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="getAllQueues">
+            <wsdl:input message="tns:getAllQueuesRequest" wsaw:Action="urn:getAllQueues"/>
+            <wsdl:output message="tns:getAllQueuesResponse" wsaw:Action="urn:getAllQueuesResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getAllQueuesAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteQueuePermission">
+            <wsdl:input message="tns:checkUserHasDeleteQueuePermissionRequest" wsaw:Action="urn:checkUserHasDeleteQueuePermission"/>
+            <wsdl:output message="tns:checkUserHasDeleteQueuePermissionResponse" wsaw:Action="urn:checkUserHasDeleteQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasDeleteQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageMetadataInDeadLetterChannel">
+            <wsdl:input message="tns:getMessageMetadataInDeadLetterChannelRequest" wsaw:Action="urn:getMessageMetadataInDeadLetterChannel"/>
+            <wsdl:output message="tns:getMessageMetadataInDeadLetterChannelResponse" wsaw:Action="urn:getMessageMetadataInDeadLetterChannelResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getMessageMetadataInDeadLetterChannelAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getTotalMessagesInQueue">
+            <wsdl:input message="tns:getTotalMessagesInQueueRequest" wsaw:Action="urn:getTotalMessagesInQueue"/>
+            <wsdl:output message="tns:getTotalMessagesInQueueResponse" wsaw:Action="urn:getTotalMessagesInQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getTotalMessagesInQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageCountForSubscriber">
+            <wsdl:input message="tns:getMessageCountForSubscriberRequest" wsaw:Action="urn:getMessageCountForSubscriber"/>
+            <wsdl:output message="tns:getMessageCountForSubscriberResponse" wsaw:Action="urn:getMessageCountForSubscriberResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getMessageCountForSubscriberAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getNamesOfAllDurableQueues">
+            <wsdl:input message="tns:getNamesOfAllDurableQueuesRequest" wsaw:Action="urn:getNamesOfAllDurableQueues"/>
+            <wsdl:output message="tns:getNamesOfAllDurableQueuesResponse" wsaw:Action="urn:getNamesOfAllDurableQueuesResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getNamesOfAllDurableQueuesAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="addQueueAndAssignPermission">
+            <wsdl:input message="tns:addQueueAndAssignPermissionRequest" wsaw:Action="urn:addQueueAndAssignPermission"/>
+            <wsdl:output message="tns:addQueueAndAssignPermissionResponse" wsaw:Action="urn:addQueueAndAssignPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:addQueueAndAssignPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="browseQueue">
+            <wsdl:input message="tns:browseQueueRequest" wsaw:Action="urn:browseQueue"/>
+            <wsdl:output message="tns:browseQueueResponse" wsaw:Action="urn:browseQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:browseQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
+            <wsdl:input message="tns:getTotalSubscriptionCountForSearchResultRequest" wsaw:Action="urn:getTotalSubscriptionCountForSearchResult"/>
+            <wsdl:output message="tns:getTotalSubscriptionCountForSearchResultResponse" wsaw:Action="urn:getTotalSubscriptionCountForSearchResultResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getTotalSubscriptionCountForSearchResultAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="purgeMessagesOfQueue">
+            <wsdl:input message="tns:purgeMessagesOfQueueRequest" wsaw:Action="urn:purgeMessagesOfQueue"/>
+            <wsdl:output message="tns:purgeMessagesOfQueueResponse" wsaw:Action="urn:purgeMessagesOfQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:purgeMessagesOfQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPurgeQueuePermission">
+            <wsdl:input message="tns:checkUserHasPurgeQueuePermissionRequest" wsaw:Action="urn:checkUserHasPurgeQueuePermission"/>
+            <wsdl:output message="tns:checkUserHasPurgeQueuePermissionResponse" wsaw:Action="urn:checkUserHasPurgeQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasPurgeQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasQueueSubscriptionClosePermission">
+            <wsdl:input message="tns:checkCurrentUserHasQueueSubscriptionClosePermissionRequest" wsaw:Action="urn:checkCurrentUserHasQueueSubscriptionClosePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasQueueSubscriptionClosePermissionResponse" wsaw:Action="urn:checkCurrentUserHasQueueSubscriptionClosePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasQueueSubscriptionClosePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
+            <wsdl:input message="tns:checkUserHasRestoreMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasRestoreMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkUserHasRestoreMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasRestoreMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasRestoreMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasAddQueuePermission">
+            <wsdl:input message="tns:checkUserHasAddQueuePermissionRequest" wsaw:Action="urn:checkUserHasAddQueuePermission"/>
+            <wsdl:output message="tns:checkUserHasAddQueuePermissionResponse" wsaw:Action="urn:checkUserHasAddQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasAddQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getQueueByName">
+            <wsdl:input message="tns:getQueueByNameRequest" wsaw:Action="urn:getQueueByName"/>
+            <wsdl:output message="tns:getQueueByNameResponse" wsaw:Action="urn:getQueueByNameResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getQueueByNameAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasBrowseQueuePermission">
+            <wsdl:input message="tns:checkUserHasBrowseQueuePermissionRequest" wsaw:Action="urn:checkUserHasBrowseQueuePermission"/>
+            <wsdl:output message="tns:checkUserHasBrowseQueuePermissionResponse" wsaw:Action="urn:checkUserHasBrowseQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasBrowseQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPublishPermission">
+            <wsdl:input message="tns:checkCurrentUserHasPublishPermissionRequest" wsaw:Action="urn:checkCurrentUserHasPublishPermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasPublishPermissionResponse" wsaw:Action="urn:checkCurrentUserHasPublishPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasPublishPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
+            <wsdl:input message="tns:checkCurrentUserHasPurgeQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasPurgeQueuePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasPurgeQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasPurgeQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasPurgeQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getDLCQueue">
+            <wsdl:input message="tns:getDLCQueueRequest" wsaw:Action="urn:getDLCQueue"/>
+            <wsdl:output message="tns:getDLCQueueResponse" wsaw:Action="urn:getDLCQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getDLCQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
+            <wsdl:input message="tns:checkUserHasDeleteMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasDeleteMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkUserHasDeleteMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasDeleteMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasDeleteMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getNumberOfMessagesInDLCForQueue">
+            <wsdl:input message="tns:getNumberOfMessagesInDLCForQueueRequest" wsaw:Action="urn:getNumberOfMessagesInDLCForQueue"/>
+            <wsdl:output message="tns:getNumberOfMessagesInDLCForQueueResponse" wsaw:Action="urn:getNumberOfMessagesInDLCForQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getNumberOfMessagesInDLCForQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="rerouteSelectedMessagesFromDeadLetterChannel">
+            <wsdl:input message="tns:rerouteSelectedMessagesFromDeadLetterChannelRequest" wsaw:Action="urn:rerouteSelectedMessagesFromDeadLetterChannel"/>
+            <wsdl:output message="tns:rerouteSelectedMessagesFromDeadLetterChannelResponse" wsaw:Action="urn:rerouteSelectedMessagesFromDeadLetterChannelResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:rerouteSelectedMessagesFromDeadLetterChannelAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
+            <wsdl:input message="tns:checkCurrentUserHasRerouteMessagesInDLCPermissionRequest" wsaw:Action="urn:checkCurrentUserHasRerouteMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasRerouteMessagesInDLCPermissionResponse" wsaw:Action="urn:checkCurrentUserHasRerouteMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasRerouteMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="restoreSelectedMessagesFromDeadLetterChannel">
+            <wsdl:input message="tns:restoreSelectedMessagesFromDeadLetterChannelRequest" wsaw:Action="urn:restoreSelectedMessagesFromDeadLetterChannel"/>
+            <wsdl:output message="tns:restoreSelectedMessagesFromDeadLetterChannelResponse" wsaw:Action="urn:restoreSelectedMessagesFromDeadLetterChannelResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:restoreSelectedMessagesFromDeadLetterChannelAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getFilteredSubscriptions">
+            <wsdl:input message="tns:getFilteredSubscriptionsRequest" wsaw:Action="urn:getFilteredSubscriptions"/>
+            <wsdl:output message="tns:getFilteredSubscriptionsResponse" wsaw:Action="urn:getFilteredSubscriptionsResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getFilteredSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
+            <wsdl:input message="tns:checkCurrentUserHasRestoreMessagesInDLCPermissionRequest" wsaw:Action="urn:checkCurrentUserHasRestoreMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasRestoreMessagesInDLCPermissionResponse" wsaw:Action="urn:checkCurrentUserHasRestoreMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasRestoreMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="updatePermission">
+            <wsdl:input message="tns:updatePermissionRequest" wsaw:Action="urn:updatePermission"/>
+            <wsdl:output message="tns:updatePermissionResponse" wsaw:Action="urn:updatePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:updatePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPublishPermission">
+            <wsdl:input message="tns:checkUserHasPublishPermissionRequest" wsaw:Action="urn:checkUserHasPublishPermission"/>
+            <wsdl:output message="tns:checkUserHasPublishPermissionResponse" wsaw:Action="urn:checkUserHasPublishPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasPublishPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasBrowseMessagesInDLCPermission">
+            <wsdl:input message="tns:checkCurrentUserHasBrowseMessagesInDLCPermissionRequest" wsaw:Action="urn:checkCurrentUserHasBrowseMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasBrowseMessagesInDLCPermissionResponse" wsaw:Action="urn:checkCurrentUserHasBrowseMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasBrowseMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="closeSubscription">
+            <wsdl:input message="tns:closeSubscriptionRequest" wsaw:Action="urn:closeSubscription"/>
+            <wsdl:output message="tns:closeSubscriptionResponse" wsaw:Action="urn:closeSubscriptionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:closeSubscriptionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="sendMessage">
+            <wsdl:input message="tns:sendMessageRequest" wsaw:Action="urn:sendMessage"/>
+            <wsdl:output message="tns:sendMessageResponse" wsaw:Action="urn:sendMessageResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:sendMessageAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
+            <wsdl:input message="tns:deleteMessagesFromDeadLetterQueueRequest" wsaw:Action="urn:deleteMessagesFromDeadLetterQueue"/>
+            <wsdl:output message="tns:deleteMessagesFromDeadLetterQueueResponse" wsaw:Action="urn:deleteMessagesFromDeadLetterQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteMessagesFromDeadLetterQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="deleteTopicFromRegistry">
+            <wsdl:input message="tns:deleteTopicFromRegistryRequest" wsaw:Action="urn:deleteTopicFromRegistry"/>
+            <wsdl:output message="tns:deleteTopicFromRegistryResponse" wsaw:Action="urn:deleteTopicFromRegistryResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteTopicFromRegistryAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
+            <wsdl:input message="tns:checkCurrentUserHasDeleteQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasDeleteQueuePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasDeleteQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasDeleteQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasDeleteQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getQueueRolePermission">
+            <wsdl:input message="tns:getQueueRolePermissionRequest" wsaw:Action="urn:getQueueRolePermission"/>
+            <wsdl:output message="tns:getQueueRolePermissionResponse" wsaw:Action="urn:getQueueRolePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getQueueRolePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
+            <wsdl:input message="tns:checkCurrentUserHasAddQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasAddQueuePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasAddQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasAddQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasAddQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="deleteQueue">
+            <wsdl:input message="tns:deleteQueueRequest" wsaw:Action="urn:deleteQueue"/>
+            <wsdl:output message="tns:deleteQueueResponse" wsaw:Action="urn:deleteQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
+            <wsdl:input message="tns:checkCurrentUserHasTopicSubscriptionClosePermissionRequest" wsaw:Action="urn:checkCurrentUserHasTopicSubscriptionClosePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasTopicSubscriptionClosePermissionResponse" wsaw:Action="urn:checkCurrentUserHasTopicSubscriptionClosePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasTopicSubscriptionClosePermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="AndesAdminServiceSoap11Binding" type="tns:AndesAdminServicePortType">
         <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
-        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
-            <soap:operation soapAction="urn:deleteMessagesFromDeadLetterQueue" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getAllDurableTopicSubscriptions">
-            <soap:operation soapAction="urn:getAllDurableTopicSubscriptions" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getAllQueues">
-            <soap:operation soapAction="urn:getAllQueues" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getAccessKey">
-            <soap:operation soapAction="urn:getAccessKey" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getAllLocalTempQueueSubscriptions">
-            <soap:operation soapAction="urn:getAllLocalTempQueueSubscriptions" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getAllDurableQueueSubscriptions">
-            <soap:operation soapAction="urn:getAllDurableQueueSubscriptions" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="sendMessage">
-            <soap:operation soapAction="urn:sendMessage" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="updatePermission">
-            <soap:operation soapAction="urn:updatePermission" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="createQueue">
-            <soap:operation soapAction="urn:createQueue" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="deleteTopicFromRegistry">
-            <soap:operation soapAction="urn:deleteTopicFromRegistry" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueue">
-            <soap:operation soapAction="urn:restoreMessagesFromDeadLetterQueue" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="purgeMessagesOfQueue">
-            <soap:operation soapAction="urn:purgeMessagesOfQueue" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageCountForSubscriber">
-            <soap:operation soapAction="urn:getMessageCountForSubscriber" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="browseQueue">
-            <soap:operation soapAction="urn:browseQueue" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getTotalMessagesInQueue">
-            <soap:operation soapAction="urn:getTotalMessagesInQueue" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="deleteQueue">
-            <soap:operation soapAction="urn:deleteQueue" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getAllLocalTempTopicSubscriptions">
-            <soap:operation soapAction="urn:getAllLocalTempTopicSubscriptions" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getQueueRolePermission">
-            <soap:operation soapAction="urn:getQueueRolePermission" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getUserRoles">
-            <soap:operation soapAction="urn:getUserRoles" style="document"/>
+        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkUserHasBrowseMessagesInDLCPermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -791,6 +1302,114 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
+        <wsdl:operation name="getMessagesInDLCForQueue">
+            <soap:operation soapAction="urn:getMessagesInDLCForQueue" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="dumpMessageStatus">
+            <soap:operation soapAction="urn:dumpMessageStatus" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getUserRoles">
+            <soap:operation soapAction="urn:getUserRoles" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasBrowseQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="rerouteAllMessagesFromDeadLetterChannelForQueue">
+            <soap:operation soapAction="urn:rerouteAllMessagesFromDeadLetterChannelForQueue" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getPendingMessageCount">
+            <soap:operation soapAction="urn:getPendingMessageCount" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getSubscriptions">
+            <soap:operation soapAction="urn:getSubscriptions" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasDeleteMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasDeleteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkUserHasRerouteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
         <wsdl:operation name="getAllSubscriptions">
             <soap:operation soapAction="urn:getAllSubscriptions" style="document"/>
             <wsdl:input>
@@ -803,8 +1422,452 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueueWithDifferentDestination">
-            <soap:operation soapAction="urn:restoreMessagesFromDeadLetterQueueWithDifferentDestination" style="document"/>
+        <wsdl:operation name="getAllQueues">
+            <soap:operation soapAction="urn:getAllQueues" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteQueuePermission">
+            <soap:operation soapAction="urn:checkUserHasDeleteQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageMetadataInDeadLetterChannel">
+            <soap:operation soapAction="urn:getMessageMetadataInDeadLetterChannel" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getTotalMessagesInQueue">
+            <soap:operation soapAction="urn:getTotalMessagesInQueue" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageCountForSubscriber">
+            <soap:operation soapAction="urn:getMessageCountForSubscriber" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getNamesOfAllDurableQueues">
+            <soap:operation soapAction="urn:getNamesOfAllDurableQueues" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="addQueueAndAssignPermission">
+            <soap:operation soapAction="urn:addQueueAndAssignPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="browseQueue">
+            <soap:operation soapAction="urn:browseQueue" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
+            <soap:operation soapAction="urn:getTotalSubscriptionCountForSearchResult" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="purgeMessagesOfQueue">
+            <soap:operation soapAction="urn:purgeMessagesOfQueue" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPurgeQueuePermission">
+            <soap:operation soapAction="urn:checkUserHasPurgeQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasQueueSubscriptionClosePermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasQueueSubscriptionClosePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkUserHasRestoreMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasAddQueuePermission">
+            <soap:operation soapAction="urn:checkUserHasAddQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getQueueByName">
+            <soap:operation soapAction="urn:getQueueByName" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasBrowseQueuePermission">
+            <soap:operation soapAction="urn:checkUserHasBrowseQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPublishPermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasPublishPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasPurgeQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getDLCQueue">
+            <soap:operation soapAction="urn:getDLCQueue" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkUserHasDeleteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getNumberOfMessagesInDLCForQueue">
+            <soap:operation soapAction="urn:getNumberOfMessagesInDLCForQueue" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="rerouteSelectedMessagesFromDeadLetterChannel">
+            <soap:operation soapAction="urn:rerouteSelectedMessagesFromDeadLetterChannel" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasRerouteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="restoreSelectedMessagesFromDeadLetterChannel">
+            <soap:operation soapAction="urn:restoreSelectedMessagesFromDeadLetterChannel" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getFilteredSubscriptions">
+            <soap:operation soapAction="urn:getFilteredSubscriptions" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasRestoreMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="updatePermission">
+            <soap:operation soapAction="urn:updatePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPublishPermission">
+            <soap:operation soapAction="urn:checkUserHasPublishPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasBrowseMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasBrowseMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="closeSubscription">
+            <soap:operation soapAction="urn:closeSubscription" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="sendMessage">
+            <soap:operation soapAction="urn:sendMessage" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
+            <soap:operation soapAction="urn:deleteMessagesFromDeadLetterQueue" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="deleteTopicFromRegistry">
+            <soap:operation soapAction="urn:deleteTopicFromRegistry" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasDeleteQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getQueueRolePermission">
+            <soap:operation soapAction="urn:getQueueRolePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasAddQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="deleteQueue">
+            <soap:operation soapAction="urn:deleteQueue" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasTopicSubscriptionClosePermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -818,221 +1881,8 @@
     </wsdl:binding>
     <wsdl:binding name="AndesAdminServiceSoap12Binding" type="tns:AndesAdminServicePortType">
         <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
-        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
-            <soap12:operation soapAction="urn:deleteMessagesFromDeadLetterQueue" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getAllDurableTopicSubscriptions">
-            <soap12:operation soapAction="urn:getAllDurableTopicSubscriptions" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getAllQueues">
-            <soap12:operation soapAction="urn:getAllQueues" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getAccessKey">
-            <soap12:operation soapAction="urn:getAccessKey" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getAllLocalTempQueueSubscriptions">
-            <soap12:operation soapAction="urn:getAllLocalTempQueueSubscriptions" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getAllDurableQueueSubscriptions">
-            <soap12:operation soapAction="urn:getAllDurableQueueSubscriptions" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="sendMessage">
-            <soap12:operation soapAction="urn:sendMessage" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="updatePermission">
-            <soap12:operation soapAction="urn:updatePermission" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="createQueue">
-            <soap12:operation soapAction="urn:createQueue" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="deleteTopicFromRegistry">
-            <soap12:operation soapAction="urn:deleteTopicFromRegistry" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueue">
-            <soap12:operation soapAction="urn:restoreMessagesFromDeadLetterQueue" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="purgeMessagesOfQueue">
-            <soap12:operation soapAction="urn:purgeMessagesOfQueue" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageCountForSubscriber">
-            <soap12:operation soapAction="urn:getMessageCountForSubscriber" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="browseQueue">
-            <soap12:operation soapAction="urn:browseQueue" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getTotalMessagesInQueue">
-            <soap12:operation soapAction="urn:getTotalMessagesInQueue" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="deleteQueue">
-            <soap12:operation soapAction="urn:deleteQueue" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getAllLocalTempTopicSubscriptions">
-            <soap12:operation soapAction="urn:getAllLocalTempTopicSubscriptions" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getQueueRolePermission">
-            <soap12:operation soapAction="urn:getQueueRolePermission" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getUserRoles">
-            <soap12:operation soapAction="urn:getUserRoles" style="document"/>
+        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkUserHasBrowseMessagesInDLCPermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -1055,6 +1905,114 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
+        <wsdl:operation name="getMessagesInDLCForQueue">
+            <soap12:operation soapAction="urn:getMessagesInDLCForQueue" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="dumpMessageStatus">
+            <soap12:operation soapAction="urn:dumpMessageStatus" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getUserRoles">
+            <soap12:operation soapAction="urn:getUserRoles" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasBrowseQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="rerouteAllMessagesFromDeadLetterChannelForQueue">
+            <soap12:operation soapAction="urn:rerouteAllMessagesFromDeadLetterChannelForQueue" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getPendingMessageCount">
+            <soap12:operation soapAction="urn:getPendingMessageCount" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getSubscriptions">
+            <soap12:operation soapAction="urn:getSubscriptions" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasDeleteMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasDeleteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkUserHasRerouteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
         <wsdl:operation name="getAllSubscriptions">
             <soap12:operation soapAction="urn:getAllSubscriptions" style="document"/>
             <wsdl:input>
@@ -1067,8 +2025,452 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueueWithDifferentDestination">
-            <soap12:operation soapAction="urn:restoreMessagesFromDeadLetterQueueWithDifferentDestination" style="document"/>
+        <wsdl:operation name="getAllQueues">
+            <soap12:operation soapAction="urn:getAllQueues" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteQueuePermission">
+            <soap12:operation soapAction="urn:checkUserHasDeleteQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageMetadataInDeadLetterChannel">
+            <soap12:operation soapAction="urn:getMessageMetadataInDeadLetterChannel" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getTotalMessagesInQueue">
+            <soap12:operation soapAction="urn:getTotalMessagesInQueue" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageCountForSubscriber">
+            <soap12:operation soapAction="urn:getMessageCountForSubscriber" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getNamesOfAllDurableQueues">
+            <soap12:operation soapAction="urn:getNamesOfAllDurableQueues" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="addQueueAndAssignPermission">
+            <soap12:operation soapAction="urn:addQueueAndAssignPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="browseQueue">
+            <soap12:operation soapAction="urn:browseQueue" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
+            <soap12:operation soapAction="urn:getTotalSubscriptionCountForSearchResult" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="purgeMessagesOfQueue">
+            <soap12:operation soapAction="urn:purgeMessagesOfQueue" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPurgeQueuePermission">
+            <soap12:operation soapAction="urn:checkUserHasPurgeQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasQueueSubscriptionClosePermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasQueueSubscriptionClosePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkUserHasRestoreMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasAddQueuePermission">
+            <soap12:operation soapAction="urn:checkUserHasAddQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getQueueByName">
+            <soap12:operation soapAction="urn:getQueueByName" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasBrowseQueuePermission">
+            <soap12:operation soapAction="urn:checkUserHasBrowseQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPublishPermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasPublishPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasPurgeQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getDLCQueue">
+            <soap12:operation soapAction="urn:getDLCQueue" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkUserHasDeleteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getNumberOfMessagesInDLCForQueue">
+            <soap12:operation soapAction="urn:getNumberOfMessagesInDLCForQueue" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="rerouteSelectedMessagesFromDeadLetterChannel">
+            <soap12:operation soapAction="urn:rerouteSelectedMessagesFromDeadLetterChannel" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasRerouteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="restoreSelectedMessagesFromDeadLetterChannel">
+            <soap12:operation soapAction="urn:restoreSelectedMessagesFromDeadLetterChannel" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getFilteredSubscriptions">
+            <soap12:operation soapAction="urn:getFilteredSubscriptions" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasRestoreMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="updatePermission">
+            <soap12:operation soapAction="urn:updatePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPublishPermission">
+            <soap12:operation soapAction="urn:checkUserHasPublishPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasBrowseMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasBrowseMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="closeSubscription">
+            <soap12:operation soapAction="urn:closeSubscription" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="sendMessage">
+            <soap12:operation soapAction="urn:sendMessage" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
+            <soap12:operation soapAction="urn:deleteMessagesFromDeadLetterQueue" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="deleteTopicFromRegistry">
+            <soap12:operation soapAction="urn:deleteTopicFromRegistry" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasDeleteQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getQueueRolePermission">
+            <soap12:operation soapAction="urn:getQueueRolePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasAddQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="deleteQueue">
+            <soap12:operation soapAction="urn:deleteQueue" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasTopicSubscriptionClosePermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -1082,170 +2484,8 @@
     </wsdl:binding>
     <wsdl:binding name="AndesAdminServiceHttpBinding" type="tns:AndesAdminServicePortType">
         <http:binding verb="POST"/>
-        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
-            <http:operation location="deleteMessagesFromDeadLetterQueue"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getAllDurableTopicSubscriptions">
-            <http:operation location="getAllDurableTopicSubscriptions"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getAllQueues">
-            <http:operation location="getAllQueues"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getAccessKey">
-            <http:operation location="getAccessKey"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getAllLocalTempQueueSubscriptions">
-            <http:operation location="getAllLocalTempQueueSubscriptions"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getAllDurableQueueSubscriptions">
-            <http:operation location="getAllDurableQueueSubscriptions"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="sendMessage">
-            <http:operation location="sendMessage"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="updatePermission">
-            <http:operation location="updatePermission"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="createQueue">
-            <http:operation location="createQueue"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="deleteTopicFromRegistry">
-            <http:operation location="deleteTopicFromRegistry"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueue">
-            <http:operation location="restoreMessagesFromDeadLetterQueue"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="purgeMessagesOfQueue">
-            <http:operation location="purgeMessagesOfQueue"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getMessageCountForSubscriber">
-            <http:operation location="getMessageCountForSubscriber"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="browseQueue">
-            <http:operation location="browseQueue"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getTotalMessagesInQueue">
-            <http:operation location="getTotalMessagesInQueue"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="deleteQueue">
-            <http:operation location="deleteQueue"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getAllLocalTempTopicSubscriptions">
-            <http:operation location="getAllLocalTempTopicSubscriptions"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getQueueRolePermission">
-            <http:operation location="getQueueRolePermission"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getUserRoles">
-            <http:operation location="getUserRoles"/>
+        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
+            <http:operation location="checkUserHasBrowseMessagesInDLCPermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -1262,6 +2502,87 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
+        <wsdl:operation name="getMessagesInDLCForQueue">
+            <http:operation location="getMessagesInDLCForQueue"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="dumpMessageStatus">
+            <http:operation location="dumpMessageStatus"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getUserRoles">
+            <http:operation location="getUserRoles"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
+            <http:operation location="checkCurrentUserHasBrowseQueuePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="rerouteAllMessagesFromDeadLetterChannelForQueue">
+            <http:operation location="rerouteAllMessagesFromDeadLetterChannelForQueue"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getPendingMessageCount">
+            <http:operation location="getPendingMessageCount"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getSubscriptions">
+            <http:operation location="getSubscriptions"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasDeleteMessagesInDLCPermission">
+            <http:operation location="checkCurrentUserHasDeleteMessagesInDLCPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
+            <http:operation location="checkUserHasRerouteMessagesInDLCPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
         <wsdl:operation name="getAllSubscriptions">
             <http:operation location="getAllSubscriptions"/>
             <wsdl:input>
@@ -1271,8 +2592,341 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueueWithDifferentDestination">
-            <http:operation location="restoreMessagesFromDeadLetterQueueWithDifferentDestination"/>
+        <wsdl:operation name="getAllQueues">
+            <http:operation location="getAllQueues"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteQueuePermission">
+            <http:operation location="checkUserHasDeleteQueuePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageMetadataInDeadLetterChannel">
+            <http:operation location="getMessageMetadataInDeadLetterChannel"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getTotalMessagesInQueue">
+            <http:operation location="getTotalMessagesInQueue"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageCountForSubscriber">
+            <http:operation location="getMessageCountForSubscriber"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getNamesOfAllDurableQueues">
+            <http:operation location="getNamesOfAllDurableQueues"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="addQueueAndAssignPermission">
+            <http:operation location="addQueueAndAssignPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="browseQueue">
+            <http:operation location="browseQueue"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
+            <http:operation location="getTotalSubscriptionCountForSearchResult"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="purgeMessagesOfQueue">
+            <http:operation location="purgeMessagesOfQueue"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPurgeQueuePermission">
+            <http:operation location="checkUserHasPurgeQueuePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasQueueSubscriptionClosePermission">
+            <http:operation location="checkCurrentUserHasQueueSubscriptionClosePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
+            <http:operation location="checkUserHasRestoreMessagesInDLCPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasAddQueuePermission">
+            <http:operation location="checkUserHasAddQueuePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getQueueByName">
+            <http:operation location="getQueueByName"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasBrowseQueuePermission">
+            <http:operation location="checkUserHasBrowseQueuePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPublishPermission">
+            <http:operation location="checkCurrentUserHasPublishPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
+            <http:operation location="checkCurrentUserHasPurgeQueuePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getDLCQueue">
+            <http:operation location="getDLCQueue"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
+            <http:operation location="checkUserHasDeleteMessagesInDLCPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getNumberOfMessagesInDLCForQueue">
+            <http:operation location="getNumberOfMessagesInDLCForQueue"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="rerouteSelectedMessagesFromDeadLetterChannel">
+            <http:operation location="rerouteSelectedMessagesFromDeadLetterChannel"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
+            <http:operation location="checkCurrentUserHasRerouteMessagesInDLCPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="restoreSelectedMessagesFromDeadLetterChannel">
+            <http:operation location="restoreSelectedMessagesFromDeadLetterChannel"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getFilteredSubscriptions">
+            <http:operation location="getFilteredSubscriptions"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
+            <http:operation location="checkCurrentUserHasRestoreMessagesInDLCPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="updatePermission">
+            <http:operation location="updatePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPublishPermission">
+            <http:operation location="checkUserHasPublishPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasBrowseMessagesInDLCPermission">
+            <http:operation location="checkCurrentUserHasBrowseMessagesInDLCPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="closeSubscription">
+            <http:operation location="closeSubscription"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="sendMessage">
+            <http:operation location="sendMessage"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
+            <http:operation location="deleteMessagesFromDeadLetterQueue"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="deleteTopicFromRegistry">
+            <http:operation location="deleteTopicFromRegistry"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
+            <http:operation location="checkCurrentUserHasDeleteQueuePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getQueueRolePermission">
+            <http:operation location="getQueueRolePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
+            <http:operation location="checkCurrentUserHasAddQueuePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="deleteQueue">
+            <http:operation location="deleteQueue"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
+            <http:operation location="checkCurrentUserHasTopicSubscriptionClosePermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -1283,13 +2937,13 @@
     </wsdl:binding>
     <wsdl:service name="AndesAdminService">
         <wsdl:port name="AndesAdminServiceHttpsSoap11Endpoint" binding="tns:AndesAdminServiceSoap11Binding">
-            <soap:address location="https://10.100.5.49:9443/services/AndesAdminService.AndesAdminServiceHttpsSoap11Endpoint/"/>
+            <soap:address location="https://192.168.1.5:9443/services/AndesAdminService.AndesAdminServiceHttpsSoap11Endpoint/"/>
         </wsdl:port>
         <wsdl:port name="AndesAdminServiceHttpsSoap12Endpoint" binding="tns:AndesAdminServiceSoap12Binding">
-            <soap12:address location="https://10.100.5.49:9443/services/AndesAdminService.AndesAdminServiceHttpsSoap12Endpoint/"/>
+            <soap12:address location="https://192.168.1.5:9443/services/AndesAdminService.AndesAdminServiceHttpsSoap12Endpoint/"/>
         </wsdl:port>
         <wsdl:port name="AndesAdminServiceHttpsEndpoint" binding="tns:AndesAdminServiceHttpBinding">
-            <http:address location="https://10.100.5.49:9443/services/AndesAdminService.AndesAdminServiceHttpsEndpoint/"/>
+            <http:address location="https://192.168.1.5:9443/services/AndesAdminService.AndesAdminServiceHttpsEndpoint/"/>
         </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>

--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_message_reroute_ajaxprocessor.jsp
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_message_reroute_ajaxprocessor.jsp
@@ -20,7 +20,7 @@
         }
 
         try {
-            unavailableMessageCount = stub.restoreMessagesFromDeadLetterQueueWithDifferentDestination(andesMessageIDs,
+            unavailableMessageCount = stub.rerouteSelectedMessagesFromDeadLetterChannel(andesMessageIDs,
             newQueueName, nameOfQueue);
 
         } catch (AndesAdminServiceBrokerManagerAdminException e) {

--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_message_restore_ajaxprocessor.jsp
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_message_restore_ajaxprocessor.jsp
@@ -17,7 +17,7 @@
         andesMessageIDs[i] = Long.parseLong(idArray[i]);
     }
     try {
-        unavailableMessageCount = stub.restoreMessagesFromDeadLetterQueue(andesMessageIDs, nameOfQueue);
+        unavailableMessageCount = stub.restoreSelectedMessagesFromDeadLetterChannel(andesMessageIDs, nameOfQueue);
 
     } catch (AndesAdminServiceBrokerManagerAdminException e) {
         CarbonUIMessage uiMsg = new CarbonUIMessage(CarbonUIMessage.ERROR,

--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_messages_list.jsp
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_messages_list.jsp
@@ -267,7 +267,7 @@
              if (DLCQueueUtils.isDeadLetterQueue(nameOfQueue)) {
                  filteredMsgArray = stub.browseQueue(nameOfQueue, nextMessageIdToRead, msgCountPerPage);
              } else {
-                 filteredMsgArray = stub.getMessageInDLCForQueue(nameOfQueue, nextMessageIdToRead,
+                 filteredMsgArray = stub.getMessagesInDLCForQueue(nameOfQueue, nextMessageIdToRead,
                                                                  msgCountPerPage);
              }
              if (null != filteredMsgArray && filteredMsgArray.length > 0) {

--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/queue_messages_ids_ajaxprocessor.jsp
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/queue_messages_ids_ajaxprocessor.jsp
@@ -15,9 +15,9 @@
         int numberOfMessagesInDLCForQueue = (int) stub.getNumberOfMessagesInDLCForQueue(queueName);
 
         // Getting the message IDs into a string with delimiter ","
-        Message[] messageInDLCForQueue = stub.getMessageInDLCForQueue(queueName, 0, numberOfMessagesInDLCForQueue);
+        Message[] messagesInDLCForQueue = stub.getMessagesInDLCForQueue(queueName, 0, numberOfMessagesInDLCForQueue);
         for (int i = 0; i < numberOfMessagesInDLCForQueue; i++) {
-            messageIDList += messageInDLCForQueue[i].getAndesMsgMetadataId() + ",";
+            messageIDList += messagesInDLCForQueue[i].getAndesMsgMetadataId() + ",";
         }
 
         // We can remove the "," tag only if the messageIDList is not empty

--- a/service-stubs/org.wso2.carbon.andes.stub/src/main/resources/AndesAdminService.wsdl
+++ b/service-stubs/org.wso2.carbon.andes.stub/src/main/resources/AndesAdminService.wsdl
@@ -1,4 +1,4 @@
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:ns="http://wso2.org/carbon/andes/admin/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:tns="http://wso2.org/carbon/andes/admin" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:ax23="http://internal.admin.andes.carbon.wso2.org/xsd" xmlns:ax21="http://Exception.internal.admin.andes.carbon.wso2.org/xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" targetNamespace="http://wso2.org/carbon/andes/admin">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax23="http://internal.admin.andes.carbon.wso2.org/xsd" xmlns:ns="http://wso2.org/carbon/andes/admin/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://wso2.org/carbon/andes/admin" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ax21="http://Exception.internal.admin.andes.carbon.wso2.org/xsd" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://wso2.org/carbon/andes/admin">
     <wsdl:documentation>AndesAdminService</wsdl:documentation>
     <wsdl:types>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://Exception.internal.admin.andes.carbon.wso2.org/xsd">
@@ -9,6 +9,16 @@
             </xs:complexType>
         </xs:schema>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://internal.admin.andes.carbon.wso2.org/xsd">
+            <xs:complexType name="Queue">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="createdFrom" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="createdTime" nillable="true" type="xs:dateTime"/>
+                    <xs:element minOccurs="0" name="messageCount" type="xs:long"/>
+                    <xs:element minOccurs="0" name="queueDepth" type="xs:long"/>
+                    <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="updatedTime" nillable="true" type="xs:dateTime"/>
+                </xs:sequence>
+            </xs:complexType>
             <xs:complexType name="Subscription">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="active" type="xs:boolean"/>
@@ -42,16 +52,6 @@
                     <xs:element minOccurs="0" name="msgProperties" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
-            <xs:complexType name="Queue">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="createdFrom" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="createdTime" nillable="true" type="xs:dateTime"/>
-                    <xs:element minOccurs="0" name="messageCount" type="xs:long"/>
-                    <xs:element minOccurs="0" name="queueDepth" type="xs:long"/>
-                    <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="updatedTime" nillable="true" type="xs:dateTime"/>
-                </xs:sequence>
-            </xs:complexType>
             <xs:complexType name="QueueRolePermission">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="allowedToConsume" type="xs:boolean"/>
@@ -66,253 +66,7 @@
             <xs:element name="AndesAdminServiceBrokerManagerAdminException">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="BrokerManagerAdminException" nillable="true" type="ax21:BrokerManagerAdminException"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkCurrentUserHasDeleteMessagesInDLCPermission">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkCurrentUserHasDeleteMessagesInDLCPermissionResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkUserHasDeleteMessagesInDLCPermission">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkUserHasDeleteMessagesInDLCPermissionResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkCurrentUserHasRestoreMessagesInDLCPermission">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkCurrentUserHasRestoreMessagesInDLCPermissionResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkUserHasRestoreMessagesInDLCPermission">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkUserHasRestoreMessagesInDLCPermissionResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkCurrentUserHasRerouteMessagesInDLCPermission">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkCurrentUserHasRerouteMessagesInDLCPermissionResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkUserHasRerouteMessagesInDLCPermission">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkUserHasRerouteMessagesInDLCPermissionResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkCurrentUserHasQueueSubscriptionClosePermission">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkCurrentUserHasQueueSubscriptionClosePermissionResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkCurrentUserHasTopicSubscriptionClosePermission">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="checkCurrentUserHasTopicSubscriptionClosePermissionResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getSubscriptions">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="isDurable" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="isActive" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getSubscriptionsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Subscription"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getFilteredSubscriptions">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="isDurable" type="xs:boolean"/>
-                        <xs:element minOccurs="0" name="isActive" type="xs:boolean"/>
-                        <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="filteredNamePattern" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="isFilteredNameByExactMatch" type="xs:boolean"/>
-                        <xs:element minOccurs="0" name="identifierPattern" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="isIdentifierPatternByExactMatch" type="xs:boolean"/>
-                        <xs:element minOccurs="0" name="ownNodeId" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="pageNumber" type="xs:int"/>
-                        <xs:element minOccurs="0" name="subscriptionCountPerPage" type="xs:int"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getFilteredSubscriptionsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Subscription"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getTotalSubscriptionCountForSearchResult">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="isDurable" type="xs:boolean"/>
-                        <xs:element minOccurs="0" name="isActive" type="xs:boolean"/>
-                        <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="filteredNamePattern" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="isFilteredNameByExactMatch" type="xs:boolean"/>
-                        <xs:element minOccurs="0" name="identifierPattern" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="isIdentifierPatternByExactMatch" type="xs:boolean"/>
-                        <xs:element minOccurs="0" name="ownNodeId" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getTotalSubscriptionCountForSearchResultResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:int"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getNumberOfMessagesInDLCForQueue">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getNumberOfMessagesInDLCForQueueResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:long"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageInDLCForQueue">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="nextMessageIdToRead" type="xs:long"/>
-                        <xs:element minOccurs="0" name="maxMsgCount" type="xs:int"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageInDLCForQueueResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Message"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getNamesOfAllDurableQueues">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getNamesOfAllDurableQueuesResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageCount">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="destinationName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="msgPattern" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getMessageCountResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:long"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getDLCQueue">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getDLCQueueResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax23:Queue"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllQueues">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getAllQueuesResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Queue"/>
+                        <xs:element minOccurs="0" name="BrokerManagerAdminException" nillable="true" type="ax22:BrokerManagerAdminException"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -326,53 +80,7 @@
             <xs:element name="getQueueByNameResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax23:Queue"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deleteQueue">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="deleteTopicFromRegistry">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="topicName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="subscriptionId" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="restoreMessagesFromDeadLetterQueue">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="messageIDs" type="xs:long"/>
-                        <xs:element minOccurs="0" name="destinationQueueName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="restoreMessagesFromDeadLetterQueueResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:long"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="restoreMessagesFromDeadLetterQueueWithDifferentDestination">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="messageIDs" type="xs:long"/>
-                        <xs:element minOccurs="0" name="newDestinationQueueName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="destinationQueueName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="restoreMessagesFromDeadLetterQueueWithDifferentDestinationResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax24:Queue"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -411,79 +119,48 @@
             <xs:element name="getAllSubscriptionsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Subscription"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Subscription"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="updatePermission">
+            <xs:element name="getSubscriptions">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="queueRolePermissionsDTO" nillable="true" type="ax23:QueueRolePermission"/>
+                        <xs:element minOccurs="0" name="isDurable" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="isActive" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="addQueueAndAssignPermission">
+            <xs:element name="getSubscriptionsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="queueRolePermissionsDTO" nillable="true" type="ax23:QueueRolePermission"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Subscription"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getUserRoles">
-                <xs:complexType>
-                    <xs:sequence/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getUserRolesResponse">
+            <xs:element name="getFilteredSubscriptions">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="isDurable" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="isActive" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="filteredNamePattern" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="isFilteredNameByExactMatch" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="identifierPattern" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="isIdentifierPatternByExactMatch" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="ownNodeId" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="pageNumber" type="xs:int"/>
+                        <xs:element minOccurs="0" name="subscriptionCountPerPage" type="xs:int"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getQueueRolePermission">
+            <xs:element name="getFilteredSubscriptionsResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getQueueRolePermissionResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:QueueRolePermission"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="browseQueue">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="nextMessageIdToRead" type="xs:long"/>
-                        <xs:element minOccurs="0" name="maxMsgCount" type="xs:int"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="browseQueueResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:Message"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getTotalMessagesInQueue">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getTotalMessagesInQueueResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Subscription"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -682,6 +359,361 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="checkCurrentUserHasDeleteMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasDeleteMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasDeleteMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasDeleteMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasRestoreMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasRestoreMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasRestoreMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasRestoreMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasRerouteMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasRerouteMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasRerouteMessagesInDLCPermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkUserHasRerouteMessagesInDLCPermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasQueueSubscriptionClosePermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasQueueSubscriptionClosePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasTopicSubscriptionClosePermission">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="checkCurrentUserHasTopicSubscriptionClosePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageMetadataInDeadLetterChannel">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="targetQueue" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="startMessageId" type="xs:long"/>
+                        <xs:element minOccurs="0" name="pageLimit" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageMetadataInDeadLetterChannelResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Message"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="rerouteAllMessagesFromDeadLetterChannelForQueue">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="sourceQueue" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="targetQueue" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="internalBatchSize" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="rerouteAllMessagesFromDeadLetterChannelForQueueResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getDLCQueue">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getDLCQueueResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax24:Queue"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getTotalSubscriptionCountForSearchResult">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="isDurable" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="isActive" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="protocolType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="destinationType" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="filteredNamePattern" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="isFilteredNameByExactMatch" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="identifierPattern" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="isIdentifierPatternByExactMatch" type="xs:boolean"/>
+                        <xs:element minOccurs="0" name="ownNodeId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getTotalSubscriptionCountForSearchResultResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getNumberOfMessagesInDLCForQueue">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getNumberOfMessagesInDLCForQueueResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessagesInDLCForQueue">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="nextMessageIdToRead" type="xs:long"/>
+                        <xs:element minOccurs="0" name="maxMsgCount" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessagesInDLCForQueueResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Message"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="updatePermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="queueRolePermissionsDTO" nillable="true" type="ax24:QueueRolePermission"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="addQueueAndAssignPermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="queueRolePermissionsDTO" nillable="true" type="ax24:QueueRolePermission"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getUserRoles">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getUserRolesResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getQueueRolePermission">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getQueueRolePermissionResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:QueueRolePermission"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="browseQueue">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="nextMessageIdToRead" type="xs:long"/>
+                        <xs:element minOccurs="0" name="maxMsgCount" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="browseQueueResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Message"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getTotalMessagesInQueue">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getTotalMessagesInQueueResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllQueues">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getAllQueuesResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax24:Queue"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getNamesOfAllDurableQueues">
+                <xs:complexType>
+                    <xs:sequence/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getNamesOfAllDurableQueuesResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageCount">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="destinationName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="msgPattern" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getMessageCountResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteQueue">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="queueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deleteTopicFromRegistry">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="topicName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="subscriptionId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="restoreSelectedMessagesFromDeadLetterChannel">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="messageIDs" type="xs:long"/>
+                        <xs:element minOccurs="0" name="destinationQueueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="restoreSelectedMessagesFromDeadLetterChannelResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="rerouteSelectedMessagesFromDeadLetterChannel">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="messageIDs" type="xs:long"/>
+                        <xs:element minOccurs="0" name="newDestinationQueueName" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="destinationQueueName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="rerouteSelectedMessagesFromDeadLetterChannelResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:long"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="sendMessage">
                 <xs:complexType>
                     <xs:sequence>
@@ -705,100 +737,60 @@
             </xs:element>
         </xs:schema>
     </wsdl:types>
-    <wsdl:message name="addQueueAndAssignPermissionRequest">
-        <wsdl:part name="parameters" element="ns:addQueueAndAssignPermission"/>
+    <wsdl:message name="checkUserHasBrowseMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasBrowseMessagesInDLCPermission"/>
     </wsdl:message>
-    <wsdl:message name="addQueueAndAssignPermissionResponse"/>
+    <wsdl:message name="checkUserHasBrowseMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasBrowseMessagesInDLCPermissionResponse"/>
+    </wsdl:message>
     <wsdl:message name="AndesAdminServiceBrokerManagerAdminException">
         <wsdl:part name="parameters" element="ns:AndesAdminServiceBrokerManagerAdminException"/>
     </wsdl:message>
-    <wsdl:message name="deleteMessagesFromDeadLetterQueueRequest">
-        <wsdl:part name="parameters" element="ns:deleteMessagesFromDeadLetterQueue"/>
+    <wsdl:message name="getMessageCountRequest">
+        <wsdl:part name="parameters" element="ns:getMessageCount"/>
     </wsdl:message>
-    <wsdl:message name="deleteMessagesFromDeadLetterQueueResponse"/>
-    <wsdl:message name="getAllQueuesRequest">
-        <wsdl:part name="parameters" element="ns:getAllQueues"/>
+    <wsdl:message name="getMessageCountResponse">
+        <wsdl:part name="parameters" element="ns:getMessageCountResponse"/>
     </wsdl:message>
-    <wsdl:message name="getAllQueuesResponse">
-        <wsdl:part name="parameters" element="ns:getAllQueuesResponse"/>
+    <wsdl:message name="getMessagesInDLCForQueueRequest">
+        <wsdl:part name="parameters" element="ns:getMessagesInDLCForQueue"/>
     </wsdl:message>
-    <wsdl:message name="getMessageInDLCForQueueRequest">
-        <wsdl:part name="parameters" element="ns:getMessageInDLCForQueue"/>
+    <wsdl:message name="getMessagesInDLCForQueueResponse">
+        <wsdl:part name="parameters" element="ns:getMessagesInDLCForQueueResponse"/>
     </wsdl:message>
-    <wsdl:message name="getMessageInDLCForQueueResponse">
-        <wsdl:part name="parameters" element="ns:getMessageInDLCForQueueResponse"/>
+    <wsdl:message name="dumpMessageStatusRequest">
+        <wsdl:part name="parameters" element="ns:dumpMessageStatus"/>
     </wsdl:message>
-    <wsdl:message name="getFilteredSubscriptionsRequest">
-        <wsdl:part name="parameters" element="ns:getFilteredSubscriptions"/>
+    <wsdl:message name="dumpMessageStatusResponse"/>
+    <wsdl:message name="getUserRolesRequest">
+        <wsdl:part name="parameters" element="ns:getUserRoles"/>
     </wsdl:message>
-    <wsdl:message name="getFilteredSubscriptionsResponse">
-        <wsdl:part name="parameters" element="ns:getFilteredSubscriptionsResponse"/>
+    <wsdl:message name="getUserRolesResponse">
+        <wsdl:part name="parameters" element="ns:getUserRolesResponse"/>
     </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasTopicSubscriptionClosePermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasTopicSubscriptionClosePermission"/>
+    <wsdl:message name="checkCurrentUserHasBrowseQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseQueuePermission"/>
     </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasTopicSubscriptionClosePermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasTopicSubscriptionClosePermissionResponse"/>
+    <wsdl:message name="checkCurrentUserHasBrowseQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseQueuePermissionResponse"/>
     </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasDeleteQueuePermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasDeleteQueuePermission"/>
+    <wsdl:message name="rerouteAllMessagesFromDeadLetterChannelForQueueRequest">
+        <wsdl:part name="parameters" element="ns:rerouteAllMessagesFromDeadLetterChannelForQueue"/>
     </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasDeleteQueuePermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasDeleteQueuePermissionResponse"/>
+    <wsdl:message name="rerouteAllMessagesFromDeadLetterChannelForQueueResponse">
+        <wsdl:part name="parameters" element="ns:rerouteAllMessagesFromDeadLetterChannelForQueueResponse"/>
     </wsdl:message>
-    <wsdl:message name="sendMessageRequest">
-        <wsdl:part name="parameters" element="ns:sendMessage"/>
+    <wsdl:message name="getPendingMessageCountRequest">
+        <wsdl:part name="parameters" element="ns:getPendingMessageCount"/>
     </wsdl:message>
-    <wsdl:message name="sendMessageResponse">
-        <wsdl:part name="parameters" element="ns:sendMessageResponse"/>
+    <wsdl:message name="getPendingMessageCountResponse">
+        <wsdl:part name="parameters" element="ns:getPendingMessageCountResponse"/>
     </wsdl:message>
-    <wsdl:message name="updatePermissionRequest">
-        <wsdl:part name="parameters" element="ns:updatePermission"/>
-    </wsdl:message>
-    <wsdl:message name="updatePermissionResponse"/>
-    <wsdl:message name="deleteTopicFromRegistryRequest">
-        <wsdl:part name="parameters" element="ns:deleteTopicFromRegistry"/>
-    </wsdl:message>
-    <wsdl:message name="deleteTopicFromRegistryResponse"/>
     <wsdl:message name="getSubscriptionsRequest">
         <wsdl:part name="parameters" element="ns:getSubscriptions"/>
     </wsdl:message>
     <wsdl:message name="getSubscriptionsResponse">
         <wsdl:part name="parameters" element="ns:getSubscriptionsResponse"/>
-    </wsdl:message>
-    <wsdl:message name="restoreMessagesFromDeadLetterQueueRequest">
-        <wsdl:part name="parameters" element="ns:restoreMessagesFromDeadLetterQueue"/>
-    </wsdl:message>
-    <wsdl:message name="restoreMessagesFromDeadLetterQueueResponse">
-        <wsdl:part name="parameters" element="ns:restoreMessagesFromDeadLetterQueueResponse"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasPurgeQueuePermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPurgeQueuePermission"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasPurgeQueuePermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPurgeQueuePermissionResponse"/>
-    </wsdl:message>
-    <wsdl:message name="purgeMessagesOfQueueRequest">
-        <wsdl:part name="parameters" element="ns:purgeMessagesOfQueue"/>
-    </wsdl:message>
-    <wsdl:message name="purgeMessagesOfQueueResponse"/>
-    <wsdl:message name="getTotalSubscriptionCountForSearchResultRequest">
-        <wsdl:part name="parameters" element="ns:getTotalSubscriptionCountForSearchResult"/>
-    </wsdl:message>
-    <wsdl:message name="getTotalSubscriptionCountForSearchResultResponse">
-        <wsdl:part name="parameters" element="ns:getTotalSubscriptionCountForSearchResultResponse"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasPublishPermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPublishPermission"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasPublishPermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPublishPermissionResponse"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasRerouteMessagesInDLCPermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRerouteMessagesInDLCPermission"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasRerouteMessagesInDLCPermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRerouteMessagesInDLCPermissionResponse"/>
     </wsdl:message>
     <wsdl:message name="checkCurrentUserHasDeleteMessagesInDLCPermissionRequest">
         <wsdl:part name="parameters" element="ns:checkCurrentUserHasDeleteMessagesInDLCPermission"/>
@@ -806,11 +798,35 @@
     <wsdl:message name="checkCurrentUserHasDeleteMessagesInDLCPermissionResponse">
         <wsdl:part name="parameters" element="ns:checkCurrentUserHasDeleteMessagesInDLCPermissionResponse"/>
     </wsdl:message>
-    <wsdl:message name="browseQueueRequest">
-        <wsdl:part name="parameters" element="ns:browseQueue"/>
+    <wsdl:message name="checkUserHasRerouteMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasRerouteMessagesInDLCPermission"/>
     </wsdl:message>
-    <wsdl:message name="browseQueueResponse">
-        <wsdl:part name="parameters" element="ns:browseQueueResponse"/>
+    <wsdl:message name="checkUserHasRerouteMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasRerouteMessagesInDLCPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getAllSubscriptionsRequest">
+        <wsdl:part name="parameters" element="ns:getAllSubscriptions"/>
+    </wsdl:message>
+    <wsdl:message name="getAllSubscriptionsResponse">
+        <wsdl:part name="parameters" element="ns:getAllSubscriptionsResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getAllQueuesRequest">
+        <wsdl:part name="parameters" element="ns:getAllQueues"/>
+    </wsdl:message>
+    <wsdl:message name="getAllQueuesResponse">
+        <wsdl:part name="parameters" element="ns:getAllQueuesResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasDeleteQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasDeleteQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasDeleteQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasDeleteQueuePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageMetadataInDeadLetterChannelRequest">
+        <wsdl:part name="parameters" element="ns:getMessageMetadataInDeadLetterChannel"/>
+    </wsdl:message>
+    <wsdl:message name="getMessageMetadataInDeadLetterChannelResponse">
+        <wsdl:part name="parameters" element="ns:getMessageMetadataInDeadLetterChannelResponse"/>
     </wsdl:message>
     <wsdl:message name="getTotalMessagesInQueueRequest">
         <wsdl:part name="parameters" element="ns:getTotalMessagesInQueue"/>
@@ -824,27 +840,37 @@
     <wsdl:message name="getMessageCountForSubscriberResponse">
         <wsdl:part name="parameters" element="ns:getMessageCountForSubscriberResponse"/>
     </wsdl:message>
-    <wsdl:message name="deleteQueueRequest">
-        <wsdl:part name="parameters" element="ns:deleteQueue"/>
-    </wsdl:message>
-    <wsdl:message name="deleteQueueResponse"/>
     <wsdl:message name="getNamesOfAllDurableQueuesRequest">
         <wsdl:part name="parameters" element="ns:getNamesOfAllDurableQueues"/>
     </wsdl:message>
     <wsdl:message name="getNamesOfAllDurableQueuesResponse">
         <wsdl:part name="parameters" element="ns:getNamesOfAllDurableQueuesResponse"/>
     </wsdl:message>
-    <wsdl:message name="checkUserHasRestoreMessagesInDLCPermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkUserHasRestoreMessagesInDLCPermission"/>
+    <wsdl:message name="addQueueAndAssignPermissionRequest">
+        <wsdl:part name="parameters" element="ns:addQueueAndAssignPermission"/>
     </wsdl:message>
-    <wsdl:message name="checkUserHasRestoreMessagesInDLCPermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkUserHasRestoreMessagesInDLCPermissionResponse"/>
+    <wsdl:message name="addQueueAndAssignPermissionResponse"/>
+    <wsdl:message name="browseQueueRequest">
+        <wsdl:part name="parameters" element="ns:browseQueue"/>
     </wsdl:message>
-    <wsdl:message name="getQueueRolePermissionRequest">
-        <wsdl:part name="parameters" element="ns:getQueueRolePermission"/>
+    <wsdl:message name="browseQueueResponse">
+        <wsdl:part name="parameters" element="ns:browseQueueResponse"/>
     </wsdl:message>
-    <wsdl:message name="getQueueRolePermissionResponse">
-        <wsdl:part name="parameters" element="ns:getQueueRolePermissionResponse"/>
+    <wsdl:message name="getTotalSubscriptionCountForSearchResultRequest">
+        <wsdl:part name="parameters" element="ns:getTotalSubscriptionCountForSearchResult"/>
+    </wsdl:message>
+    <wsdl:message name="getTotalSubscriptionCountForSearchResultResponse">
+        <wsdl:part name="parameters" element="ns:getTotalSubscriptionCountForSearchResultResponse"/>
+    </wsdl:message>
+    <wsdl:message name="purgeMessagesOfQueueRequest">
+        <wsdl:part name="parameters" element="ns:purgeMessagesOfQueue"/>
+    </wsdl:message>
+    <wsdl:message name="purgeMessagesOfQueueResponse"/>
+    <wsdl:message name="checkUserHasPurgeQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasPurgeQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasPurgeQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasPurgeQueuePermissionResponse"/>
     </wsdl:message>
     <wsdl:message name="checkCurrentUserHasQueueSubscriptionClosePermissionRequest">
         <wsdl:part name="parameters" element="ns:checkCurrentUserHasQueueSubscriptionClosePermission"/>
@@ -852,23 +878,11 @@
     <wsdl:message name="checkCurrentUserHasQueueSubscriptionClosePermissionResponse">
         <wsdl:part name="parameters" element="ns:checkCurrentUserHasQueueSubscriptionClosePermissionResponse"/>
     </wsdl:message>
-    <wsdl:message name="getMessageCountRequest">
-        <wsdl:part name="parameters" element="ns:getMessageCount"/>
+    <wsdl:message name="checkUserHasRestoreMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasRestoreMessagesInDLCPermission"/>
     </wsdl:message>
-    <wsdl:message name="getMessageCountResponse">
-        <wsdl:part name="parameters" element="ns:getMessageCountResponse"/>
-    </wsdl:message>
-    <wsdl:message name="getUserRolesRequest">
-        <wsdl:part name="parameters" element="ns:getUserRoles"/>
-    </wsdl:message>
-    <wsdl:message name="getUserRolesResponse">
-        <wsdl:part name="parameters" element="ns:getUserRolesResponse"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasAddQueuePermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasAddQueuePermission"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasAddQueuePermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasAddQueuePermissionResponse"/>
+    <wsdl:message name="checkUserHasRestoreMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasRestoreMessagesInDLCPermissionResponse"/>
     </wsdl:message>
     <wsdl:message name="checkUserHasAddQueuePermissionRequest">
         <wsdl:part name="parameters" element="ns:checkUserHasAddQueuePermission"/>
@@ -876,73 +890,11 @@
     <wsdl:message name="checkUserHasAddQueuePermissionResponse">
         <wsdl:part name="parameters" element="ns:checkUserHasAddQueuePermissionResponse"/>
     </wsdl:message>
-    <wsdl:message name="getPendingMessageCountRequest">
-        <wsdl:part name="parameters" element="ns:getPendingMessageCount"/>
-    </wsdl:message>
-    <wsdl:message name="getPendingMessageCountResponse">
-        <wsdl:part name="parameters" element="ns:getPendingMessageCountResponse"/>
-    </wsdl:message>
-    <wsdl:message name="checkUserHasPublishPermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkUserHasPublishPermission"/>
-    </wsdl:message>
-    <wsdl:message name="checkUserHasPublishPermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkUserHasPublishPermissionResponse"/>
-    </wsdl:message>
-    <wsdl:message name="getNumberOfMessagesInDLCForQueueRequest">
-        <wsdl:part name="parameters" element="ns:getNumberOfMessagesInDLCForQueue"/>
-    </wsdl:message>
-    <wsdl:message name="getNumberOfMessagesInDLCForQueueResponse">
-        <wsdl:part name="parameters" element="ns:getNumberOfMessagesInDLCForQueueResponse"/>
-    </wsdl:message>
-    <wsdl:message name="getAllSubscriptionsRequest">
-        <wsdl:part name="parameters" element="ns:getAllSubscriptions"/>
-    </wsdl:message>
-    <wsdl:message name="getAllSubscriptionsResponse">
-        <wsdl:part name="parameters" element="ns:getAllSubscriptionsResponse"/>
-    </wsdl:message>
-    <wsdl:message name="dumpMessageStatusRequest">
-        <wsdl:part name="parameters" element="ns:dumpMessageStatus"/>
-    </wsdl:message>
-    <wsdl:message name="dumpMessageStatusResponse"/>
-    <wsdl:message name="checkCurrentUserHasBrowseMessagesInDLCPermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseMessagesInDLCPermission"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasBrowseMessagesInDLCPermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseMessagesInDLCPermissionResponse"/>
-    </wsdl:message>
-    <wsdl:message name="checkUserHasPurgeQueuePermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkUserHasPurgeQueuePermission"/>
-    </wsdl:message>
-    <wsdl:message name="checkUserHasPurgeQueuePermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkUserHasPurgeQueuePermissionResponse"/>
-    </wsdl:message>
-    <wsdl:message name="closeSubscriptionRequest">
-        <wsdl:part name="parameters" element="ns:closeSubscription"/>
-    </wsdl:message>
-    <wsdl:message name="closeSubscriptionResponse"/>
-    <wsdl:message name="checkUserHasRerouteMessagesInDLCPermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkUserHasRerouteMessagesInDLCPermission"/>
-    </wsdl:message>
-    <wsdl:message name="checkUserHasRerouteMessagesInDLCPermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkUserHasRerouteMessagesInDLCPermissionResponse"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasBrowseQueuePermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseQueuePermission"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasBrowseQueuePermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseQueuePermissionResponse"/>
-    </wsdl:message>
     <wsdl:message name="getQueueByNameRequest">
         <wsdl:part name="parameters" element="ns:getQueueByName"/>
     </wsdl:message>
     <wsdl:message name="getQueueByNameResponse">
         <wsdl:part name="parameters" element="ns:getQueueByNameResponse"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasRestoreMessagesInDLCPermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRestoreMessagesInDLCPermission"/>
-    </wsdl:message>
-    <wsdl:message name="checkCurrentUserHasRestoreMessagesInDLCPermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRestoreMessagesInDLCPermissionResponse"/>
     </wsdl:message>
     <wsdl:message name="checkUserHasBrowseQueuePermissionRequest">
         <wsdl:part name="parameters" element="ns:checkUserHasBrowseQueuePermission"/>
@@ -950,17 +902,17 @@
     <wsdl:message name="checkUserHasBrowseQueuePermissionResponse">
         <wsdl:part name="parameters" element="ns:checkUserHasBrowseQueuePermissionResponse"/>
     </wsdl:message>
-    <wsdl:message name="checkUserHasBrowseMessagesInDLCPermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkUserHasBrowseMessagesInDLCPermission"/>
+    <wsdl:message name="checkCurrentUserHasPublishPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPublishPermission"/>
     </wsdl:message>
-    <wsdl:message name="checkUserHasBrowseMessagesInDLCPermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkUserHasBrowseMessagesInDLCPermissionResponse"/>
+    <wsdl:message name="checkCurrentUserHasPublishPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPublishPermissionResponse"/>
     </wsdl:message>
-    <wsdl:message name="checkUserHasDeleteMessagesInDLCPermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkUserHasDeleteMessagesInDLCPermission"/>
+    <wsdl:message name="checkCurrentUserHasPurgeQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPurgeQueuePermission"/>
     </wsdl:message>
-    <wsdl:message name="checkUserHasDeleteMessagesInDLCPermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkUserHasDeleteMessagesInDLCPermissionResponse"/>
+    <wsdl:message name="checkCurrentUserHasPurgeQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasPurgeQueuePermissionResponse"/>
     </wsdl:message>
     <wsdl:message name="getDLCQueueRequest">
         <wsdl:part name="parameters" element="ns:getDLCQueue"/>
@@ -968,113 +920,185 @@
     <wsdl:message name="getDLCQueueResponse">
         <wsdl:part name="parameters" element="ns:getDLCQueueResponse"/>
     </wsdl:message>
-    <wsdl:message name="checkUserHasDeleteQueuePermissionRequest">
-        <wsdl:part name="parameters" element="ns:checkUserHasDeleteQueuePermission"/>
+    <wsdl:message name="checkUserHasDeleteMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasDeleteMessagesInDLCPermission"/>
     </wsdl:message>
-    <wsdl:message name="checkUserHasDeleteQueuePermissionResponse">
-        <wsdl:part name="parameters" element="ns:checkUserHasDeleteQueuePermissionResponse"/>
+    <wsdl:message name="checkUserHasDeleteMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasDeleteMessagesInDLCPermissionResponse"/>
     </wsdl:message>
-    <wsdl:message name="restoreMessagesFromDeadLetterQueueWithDifferentDestinationRequest">
-        <wsdl:part name="parameters" element="ns:restoreMessagesFromDeadLetterQueueWithDifferentDestination"/>
+    <wsdl:message name="getNumberOfMessagesInDLCForQueueRequest">
+        <wsdl:part name="parameters" element="ns:getNumberOfMessagesInDLCForQueue"/>
     </wsdl:message>
-    <wsdl:message name="restoreMessagesFromDeadLetterQueueWithDifferentDestinationResponse">
-        <wsdl:part name="parameters" element="ns:restoreMessagesFromDeadLetterQueueWithDifferentDestinationResponse"/>
+    <wsdl:message name="getNumberOfMessagesInDLCForQueueResponse">
+        <wsdl:part name="parameters" element="ns:getNumberOfMessagesInDLCForQueueResponse"/>
+    </wsdl:message>
+    <wsdl:message name="rerouteSelectedMessagesFromDeadLetterChannelRequest">
+        <wsdl:part name="parameters" element="ns:rerouteSelectedMessagesFromDeadLetterChannel"/>
+    </wsdl:message>
+    <wsdl:message name="rerouteSelectedMessagesFromDeadLetterChannelResponse">
+        <wsdl:part name="parameters" element="ns:rerouteSelectedMessagesFromDeadLetterChannelResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasRerouteMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRerouteMessagesInDLCPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasRerouteMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRerouteMessagesInDLCPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="restoreSelectedMessagesFromDeadLetterChannelRequest">
+        <wsdl:part name="parameters" element="ns:restoreSelectedMessagesFromDeadLetterChannel"/>
+    </wsdl:message>
+    <wsdl:message name="restoreSelectedMessagesFromDeadLetterChannelResponse">
+        <wsdl:part name="parameters" element="ns:restoreSelectedMessagesFromDeadLetterChannelResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getFilteredSubscriptionsRequest">
+        <wsdl:part name="parameters" element="ns:getFilteredSubscriptions"/>
+    </wsdl:message>
+    <wsdl:message name="getFilteredSubscriptionsResponse">
+        <wsdl:part name="parameters" element="ns:getFilteredSubscriptionsResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasRestoreMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRestoreMessagesInDLCPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasRestoreMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasRestoreMessagesInDLCPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="updatePermissionRequest">
+        <wsdl:part name="parameters" element="ns:updatePermission"/>
+    </wsdl:message>
+    <wsdl:message name="updatePermissionResponse"/>
+    <wsdl:message name="checkUserHasPublishPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkUserHasPublishPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkUserHasPublishPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkUserHasPublishPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasBrowseMessagesInDLCPermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseMessagesInDLCPermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasBrowseMessagesInDLCPermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasBrowseMessagesInDLCPermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="closeSubscriptionRequest">
+        <wsdl:part name="parameters" element="ns:closeSubscription"/>
+    </wsdl:message>
+    <wsdl:message name="closeSubscriptionResponse"/>
+    <wsdl:message name="sendMessageRequest">
+        <wsdl:part name="parameters" element="ns:sendMessage"/>
+    </wsdl:message>
+    <wsdl:message name="sendMessageResponse">
+        <wsdl:part name="parameters" element="ns:sendMessageResponse"/>
+    </wsdl:message>
+    <wsdl:message name="deleteMessagesFromDeadLetterQueueRequest">
+        <wsdl:part name="parameters" element="ns:deleteMessagesFromDeadLetterQueue"/>
+    </wsdl:message>
+    <wsdl:message name="deleteMessagesFromDeadLetterQueueResponse"/>
+    <wsdl:message name="deleteTopicFromRegistryRequest">
+        <wsdl:part name="parameters" element="ns:deleteTopicFromRegistry"/>
+    </wsdl:message>
+    <wsdl:message name="deleteTopicFromRegistryResponse"/>
+    <wsdl:message name="checkCurrentUserHasDeleteQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasDeleteQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasDeleteQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasDeleteQueuePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getQueueRolePermissionRequest">
+        <wsdl:part name="parameters" element="ns:getQueueRolePermission"/>
+    </wsdl:message>
+    <wsdl:message name="getQueueRolePermissionResponse">
+        <wsdl:part name="parameters" element="ns:getQueueRolePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasAddQueuePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasAddQueuePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasAddQueuePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasAddQueuePermissionResponse"/>
+    </wsdl:message>
+    <wsdl:message name="deleteQueueRequest">
+        <wsdl:part name="parameters" element="ns:deleteQueue"/>
+    </wsdl:message>
+    <wsdl:message name="deleteQueueResponse"/>
+    <wsdl:message name="checkCurrentUserHasTopicSubscriptionClosePermissionRequest">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasTopicSubscriptionClosePermission"/>
+    </wsdl:message>
+    <wsdl:message name="checkCurrentUserHasTopicSubscriptionClosePermissionResponse">
+        <wsdl:part name="parameters" element="ns:checkCurrentUserHasTopicSubscriptionClosePermissionResponse"/>
     </wsdl:message>
     <wsdl:portType name="AndesAdminServicePortType">
-        <wsdl:operation name="addQueueAndAssignPermission">
-            <wsdl:input message="tns:addQueueAndAssignPermissionRequest" wsaw:Action="urn:addQueueAndAssignPermission"/>
-            <wsdl:output message="tns:addQueueAndAssignPermissionResponse" wsaw:Action="urn:addQueueAndAssignPermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:addQueueAndAssignPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
+            <wsdl:input message="tns:checkUserHasBrowseMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasBrowseMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkUserHasBrowseMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasBrowseMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasBrowseMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
-            <wsdl:input message="tns:deleteMessagesFromDeadLetterQueueRequest" wsaw:Action="urn:deleteMessagesFromDeadLetterQueue"/>
-            <wsdl:output message="tns:deleteMessagesFromDeadLetterQueueResponse" wsaw:Action="urn:deleteMessagesFromDeadLetterQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteMessagesFromDeadLetterQueueAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="getMessageCount">
+            <wsdl:input message="tns:getMessageCountRequest" wsaw:Action="urn:getMessageCount"/>
+            <wsdl:output message="tns:getMessageCountResponse" wsaw:Action="urn:getMessageCountResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getMessageCountAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="getAllQueues">
-            <wsdl:input message="tns:getAllQueuesRequest" wsaw:Action="urn:getAllQueues"/>
-            <wsdl:output message="tns:getAllQueuesResponse" wsaw:Action="urn:getAllQueuesResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getAllQueuesAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="getMessagesInDLCForQueue">
+            <wsdl:input message="tns:getMessagesInDLCForQueueRequest" wsaw:Action="urn:getMessagesInDLCForQueue"/>
+            <wsdl:output message="tns:getMessagesInDLCForQueueResponse" wsaw:Action="urn:getMessagesInDLCForQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getMessagesInDLCForQueueAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="getMessageInDLCForQueue">
-            <wsdl:input message="tns:getMessageInDLCForQueueRequest" wsaw:Action="urn:getMessageInDLCForQueue"/>
-            <wsdl:output message="tns:getMessageInDLCForQueueResponse" wsaw:Action="urn:getMessageInDLCForQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getMessageInDLCForQueueAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="dumpMessageStatus">
+            <wsdl:input message="tns:dumpMessageStatusRequest" wsaw:Action="urn:dumpMessageStatus"/>
+            <wsdl:output message="tns:dumpMessageStatusResponse" wsaw:Action="urn:dumpMessageStatusResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:dumpMessageStatusAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="getFilteredSubscriptions">
-            <wsdl:input message="tns:getFilteredSubscriptionsRequest" wsaw:Action="urn:getFilteredSubscriptions"/>
-            <wsdl:output message="tns:getFilteredSubscriptionsResponse" wsaw:Action="urn:getFilteredSubscriptionsResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getFilteredSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="getUserRoles">
+            <wsdl:input message="tns:getUserRolesRequest" wsaw:Action="urn:getUserRoles"/>
+            <wsdl:output message="tns:getUserRolesResponse" wsaw:Action="urn:getUserRolesResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getUserRolesAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
-            <wsdl:input message="tns:checkCurrentUserHasTopicSubscriptionClosePermissionRequest" wsaw:Action="urn:checkCurrentUserHasTopicSubscriptionClosePermission"/>
-            <wsdl:output message="tns:checkCurrentUserHasTopicSubscriptionClosePermissionResponse" wsaw:Action="urn:checkCurrentUserHasTopicSubscriptionClosePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasTopicSubscriptionClosePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
+            <wsdl:input message="tns:checkCurrentUserHasBrowseQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasBrowseQueuePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasBrowseQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasBrowseQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasBrowseQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
-            <wsdl:input message="tns:checkCurrentUserHasDeleteQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasDeleteQueuePermission"/>
-            <wsdl:output message="tns:checkCurrentUserHasDeleteQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasDeleteQueuePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasDeleteQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="rerouteAllMessagesFromDeadLetterChannelForQueue">
+            <wsdl:input message="tns:rerouteAllMessagesFromDeadLetterChannelForQueueRequest" wsaw:Action="urn:rerouteAllMessagesFromDeadLetterChannelForQueue"/>
+            <wsdl:output message="tns:rerouteAllMessagesFromDeadLetterChannelForQueueResponse" wsaw:Action="urn:rerouteAllMessagesFromDeadLetterChannelForQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:rerouteAllMessagesFromDeadLetterChannelForQueueAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="sendMessage">
-            <wsdl:input message="tns:sendMessageRequest" wsaw:Action="urn:sendMessage"/>
-            <wsdl:output message="tns:sendMessageResponse" wsaw:Action="urn:sendMessageResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:sendMessageAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="updatePermission">
-            <wsdl:input message="tns:updatePermissionRequest" wsaw:Action="urn:updatePermission"/>
-            <wsdl:output message="tns:updatePermissionResponse" wsaw:Action="urn:updatePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:updatePermissionAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="deleteTopicFromRegistry">
-            <wsdl:input message="tns:deleteTopicFromRegistryRequest" wsaw:Action="urn:deleteTopicFromRegistry"/>
-            <wsdl:output message="tns:deleteTopicFromRegistryResponse" wsaw:Action="urn:deleteTopicFromRegistryResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteTopicFromRegistryAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="getPendingMessageCount">
+            <wsdl:input message="tns:getPendingMessageCountRequest" wsaw:Action="urn:getPendingMessageCount"/>
+            <wsdl:output message="tns:getPendingMessageCountResponse" wsaw:Action="urn:getPendingMessageCountResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getPendingMessageCountAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
         <wsdl:operation name="getSubscriptions">
             <wsdl:input message="tns:getSubscriptionsRequest" wsaw:Action="urn:getSubscriptions"/>
             <wsdl:output message="tns:getSubscriptionsResponse" wsaw:Action="urn:getSubscriptionsResponse"/>
             <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueue">
-            <wsdl:input message="tns:restoreMessagesFromDeadLetterQueueRequest" wsaw:Action="urn:restoreMessagesFromDeadLetterQueue"/>
-            <wsdl:output message="tns:restoreMessagesFromDeadLetterQueueResponse" wsaw:Action="urn:restoreMessagesFromDeadLetterQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:restoreMessagesFromDeadLetterQueueAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
-            <wsdl:input message="tns:checkCurrentUserHasPurgeQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasPurgeQueuePermission"/>
-            <wsdl:output message="tns:checkCurrentUserHasPurgeQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasPurgeQueuePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasPurgeQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="purgeMessagesOfQueue">
-            <wsdl:input message="tns:purgeMessagesOfQueueRequest" wsaw:Action="urn:purgeMessagesOfQueue"/>
-            <wsdl:output message="tns:purgeMessagesOfQueueResponse" wsaw:Action="urn:purgeMessagesOfQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:purgeMessagesOfQueueAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
-            <wsdl:input message="tns:getTotalSubscriptionCountForSearchResultRequest" wsaw:Action="urn:getTotalSubscriptionCountForSearchResult"/>
-            <wsdl:output message="tns:getTotalSubscriptionCountForSearchResultResponse" wsaw:Action="urn:getTotalSubscriptionCountForSearchResultResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getTotalSubscriptionCountForSearchResultAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasPublishPermission">
-            <wsdl:input message="tns:checkCurrentUserHasPublishPermissionRequest" wsaw:Action="urn:checkCurrentUserHasPublishPermission"/>
-            <wsdl:output message="tns:checkCurrentUserHasPublishPermissionResponse" wsaw:Action="urn:checkCurrentUserHasPublishPermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasPublishPermissionAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
-            <wsdl:input message="tns:checkCurrentUserHasRerouteMessagesInDLCPermissionRequest" wsaw:Action="urn:checkCurrentUserHasRerouteMessagesInDLCPermission"/>
-            <wsdl:output message="tns:checkCurrentUserHasRerouteMessagesInDLCPermissionResponse" wsaw:Action="urn:checkCurrentUserHasRerouteMessagesInDLCPermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasRerouteMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
         <wsdl:operation name="checkCurrentUserHasDeleteMessagesInDLCPermission">
             <wsdl:input message="tns:checkCurrentUserHasDeleteMessagesInDLCPermissionRequest" wsaw:Action="urn:checkCurrentUserHasDeleteMessagesInDLCPermission"/>
             <wsdl:output message="tns:checkCurrentUserHasDeleteMessagesInDLCPermissionResponse" wsaw:Action="urn:checkCurrentUserHasDeleteMessagesInDLCPermissionResponse"/>
             <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasDeleteMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="browseQueue">
-            <wsdl:input message="tns:browseQueueRequest" wsaw:Action="urn:browseQueue"/>
-            <wsdl:output message="tns:browseQueueResponse" wsaw:Action="urn:browseQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:browseQueueAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
+            <wsdl:input message="tns:checkUserHasRerouteMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasRerouteMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkUserHasRerouteMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasRerouteMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasRerouteMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getAllSubscriptions">
+            <wsdl:input message="tns:getAllSubscriptionsRequest" wsaw:Action="urn:getAllSubscriptions"/>
+            <wsdl:output message="tns:getAllSubscriptionsResponse" wsaw:Action="urn:getAllSubscriptionsResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getAllSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getAllQueues">
+            <wsdl:input message="tns:getAllQueuesRequest" wsaw:Action="urn:getAllQueues"/>
+            <wsdl:output message="tns:getAllQueuesResponse" wsaw:Action="urn:getAllQueuesResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getAllQueuesAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteQueuePermission">
+            <wsdl:input message="tns:checkUserHasDeleteQueuePermissionRequest" wsaw:Action="urn:checkUserHasDeleteQueuePermission"/>
+            <wsdl:output message="tns:checkUserHasDeleteQueuePermissionResponse" wsaw:Action="urn:checkUserHasDeleteQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasDeleteQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageMetadataInDeadLetterChannel">
+            <wsdl:input message="tns:getMessageMetadataInDeadLetterChannelRequest" wsaw:Action="urn:getMessageMetadataInDeadLetterChannel"/>
+            <wsdl:output message="tns:getMessageMetadataInDeadLetterChannelResponse" wsaw:Action="urn:getMessageMetadataInDeadLetterChannelResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getMessageMetadataInDeadLetterChannelAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
         <wsdl:operation name="getTotalMessagesInQueue">
             <wsdl:input message="tns:getTotalMessagesInQueueRequest" wsaw:Action="urn:getTotalMessagesInQueue"/>
@@ -1086,146 +1110,176 @@
             <wsdl:output message="tns:getMessageCountForSubscriberResponse" wsaw:Action="urn:getMessageCountForSubscriberResponse"/>
             <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getMessageCountForSubscriberAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="deleteQueue">
-            <wsdl:input message="tns:deleteQueueRequest" wsaw:Action="urn:deleteQueue"/>
-            <wsdl:output message="tns:deleteQueueResponse" wsaw:Action="urn:deleteQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteQueueAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
         <wsdl:operation name="getNamesOfAllDurableQueues">
             <wsdl:input message="tns:getNamesOfAllDurableQueuesRequest" wsaw:Action="urn:getNamesOfAllDurableQueues"/>
             <wsdl:output message="tns:getNamesOfAllDurableQueuesResponse" wsaw:Action="urn:getNamesOfAllDurableQueuesResponse"/>
             <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getNamesOfAllDurableQueuesAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
-            <wsdl:input message="tns:checkUserHasRestoreMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasRestoreMessagesInDLCPermission"/>
-            <wsdl:output message="tns:checkUserHasRestoreMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasRestoreMessagesInDLCPermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasRestoreMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="addQueueAndAssignPermission">
+            <wsdl:input message="tns:addQueueAndAssignPermissionRequest" wsaw:Action="urn:addQueueAndAssignPermission"/>
+            <wsdl:output message="tns:addQueueAndAssignPermissionResponse" wsaw:Action="urn:addQueueAndAssignPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:addQueueAndAssignPermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="getQueueRolePermission">
-            <wsdl:input message="tns:getQueueRolePermissionRequest" wsaw:Action="urn:getQueueRolePermission"/>
-            <wsdl:output message="tns:getQueueRolePermissionResponse" wsaw:Action="urn:getQueueRolePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getQueueRolePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="browseQueue">
+            <wsdl:input message="tns:browseQueueRequest" wsaw:Action="urn:browseQueue"/>
+            <wsdl:output message="tns:browseQueueResponse" wsaw:Action="urn:browseQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:browseQueueAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasQueueSubscriptionClosePermission">
-            <wsdl:input message="tns:checkCurrentUserHasQueueSubscriptionClosePermissionRequest" wsaw:Action="urn:checkCurrentUserHasQueueSubscriptionClosePermission"/>
-            <wsdl:output message="tns:checkCurrentUserHasQueueSubscriptionClosePermissionResponse" wsaw:Action="urn:checkCurrentUserHasQueueSubscriptionClosePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasQueueSubscriptionClosePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
+            <wsdl:input message="tns:getTotalSubscriptionCountForSearchResultRequest" wsaw:Action="urn:getTotalSubscriptionCountForSearchResult"/>
+            <wsdl:output message="tns:getTotalSubscriptionCountForSearchResultResponse" wsaw:Action="urn:getTotalSubscriptionCountForSearchResultResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getTotalSubscriptionCountForSearchResultAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="getMessageCount">
-            <wsdl:input message="tns:getMessageCountRequest" wsaw:Action="urn:getMessageCount"/>
-            <wsdl:output message="tns:getMessageCountResponse" wsaw:Action="urn:getMessageCountResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getMessageCountAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getUserRoles">
-            <wsdl:input message="tns:getUserRolesRequest" wsaw:Action="urn:getUserRoles"/>
-            <wsdl:output message="tns:getUserRolesResponse" wsaw:Action="urn:getUserRolesResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getUserRolesAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
-            <wsdl:input message="tns:checkCurrentUserHasAddQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasAddQueuePermission"/>
-            <wsdl:output message="tns:checkCurrentUserHasAddQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasAddQueuePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasAddQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="checkUserHasAddQueuePermission">
-            <wsdl:input message="tns:checkUserHasAddQueuePermissionRequest" wsaw:Action="urn:checkUserHasAddQueuePermission"/>
-            <wsdl:output message="tns:checkUserHasAddQueuePermissionResponse" wsaw:Action="urn:checkUserHasAddQueuePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasAddQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getPendingMessageCount">
-            <wsdl:input message="tns:getPendingMessageCountRequest" wsaw:Action="urn:getPendingMessageCount"/>
-            <wsdl:output message="tns:getPendingMessageCountResponse" wsaw:Action="urn:getPendingMessageCountResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getPendingMessageCountAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="checkUserHasPublishPermission">
-            <wsdl:input message="tns:checkUserHasPublishPermissionRequest" wsaw:Action="urn:checkUserHasPublishPermission"/>
-            <wsdl:output message="tns:checkUserHasPublishPermissionResponse" wsaw:Action="urn:checkUserHasPublishPermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasPublishPermissionAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getNumberOfMessagesInDLCForQueue">
-            <wsdl:input message="tns:getNumberOfMessagesInDLCForQueueRequest" wsaw:Action="urn:getNumberOfMessagesInDLCForQueue"/>
-            <wsdl:output message="tns:getNumberOfMessagesInDLCForQueueResponse" wsaw:Action="urn:getNumberOfMessagesInDLCForQueueResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getNumberOfMessagesInDLCForQueueAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="getAllSubscriptions">
-            <wsdl:input message="tns:getAllSubscriptionsRequest" wsaw:Action="urn:getAllSubscriptions"/>
-            <wsdl:output message="tns:getAllSubscriptionsResponse" wsaw:Action="urn:getAllSubscriptionsResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getAllSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="dumpMessageStatus">
-            <wsdl:input message="tns:dumpMessageStatusRequest" wsaw:Action="urn:dumpMessageStatus"/>
-            <wsdl:output message="tns:dumpMessageStatusResponse" wsaw:Action="urn:dumpMessageStatusResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:dumpMessageStatusAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasBrowseMessagesInDLCPermission">
-            <wsdl:input message="tns:checkCurrentUserHasBrowseMessagesInDLCPermissionRequest" wsaw:Action="urn:checkCurrentUserHasBrowseMessagesInDLCPermission"/>
-            <wsdl:output message="tns:checkCurrentUserHasBrowseMessagesInDLCPermissionResponse" wsaw:Action="urn:checkCurrentUserHasBrowseMessagesInDLCPermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasBrowseMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="purgeMessagesOfQueue">
+            <wsdl:input message="tns:purgeMessagesOfQueueRequest" wsaw:Action="urn:purgeMessagesOfQueue"/>
+            <wsdl:output message="tns:purgeMessagesOfQueueResponse" wsaw:Action="urn:purgeMessagesOfQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:purgeMessagesOfQueueAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
         <wsdl:operation name="checkUserHasPurgeQueuePermission">
             <wsdl:input message="tns:checkUserHasPurgeQueuePermissionRequest" wsaw:Action="urn:checkUserHasPurgeQueuePermission"/>
             <wsdl:output message="tns:checkUserHasPurgeQueuePermissionResponse" wsaw:Action="urn:checkUserHasPurgeQueuePermissionResponse"/>
             <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasPurgeQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="closeSubscription">
-            <wsdl:input message="tns:closeSubscriptionRequest" wsaw:Action="urn:closeSubscription"/>
-            <wsdl:output message="tns:closeSubscriptionResponse" wsaw:Action="urn:closeSubscriptionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:closeSubscriptionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="checkCurrentUserHasQueueSubscriptionClosePermission">
+            <wsdl:input message="tns:checkCurrentUserHasQueueSubscriptionClosePermissionRequest" wsaw:Action="urn:checkCurrentUserHasQueueSubscriptionClosePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasQueueSubscriptionClosePermissionResponse" wsaw:Action="urn:checkCurrentUserHasQueueSubscriptionClosePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasQueueSubscriptionClosePermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
-            <wsdl:input message="tns:checkUserHasRerouteMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasRerouteMessagesInDLCPermission"/>
-            <wsdl:output message="tns:checkUserHasRerouteMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasRerouteMessagesInDLCPermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasRerouteMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
+            <wsdl:input message="tns:checkUserHasRestoreMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasRestoreMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkUserHasRestoreMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasRestoreMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasRestoreMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
-            <wsdl:input message="tns:checkCurrentUserHasBrowseQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasBrowseQueuePermission"/>
-            <wsdl:output message="tns:checkCurrentUserHasBrowseQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasBrowseQueuePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasBrowseQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="checkUserHasAddQueuePermission">
+            <wsdl:input message="tns:checkUserHasAddQueuePermissionRequest" wsaw:Action="urn:checkUserHasAddQueuePermission"/>
+            <wsdl:output message="tns:checkUserHasAddQueuePermissionResponse" wsaw:Action="urn:checkUserHasAddQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasAddQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
         <wsdl:operation name="getQueueByName">
             <wsdl:input message="tns:getQueueByNameRequest" wsaw:Action="urn:getQueueByName"/>
             <wsdl:output message="tns:getQueueByNameResponse" wsaw:Action="urn:getQueueByNameResponse"/>
             <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getQueueByNameAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
-            <wsdl:input message="tns:checkCurrentUserHasRestoreMessagesInDLCPermissionRequest" wsaw:Action="urn:checkCurrentUserHasRestoreMessagesInDLCPermission"/>
-            <wsdl:output message="tns:checkCurrentUserHasRestoreMessagesInDLCPermissionResponse" wsaw:Action="urn:checkCurrentUserHasRestoreMessagesInDLCPermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasRestoreMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
-        </wsdl:operation>
         <wsdl:operation name="checkUserHasBrowseQueuePermission">
             <wsdl:input message="tns:checkUserHasBrowseQueuePermissionRequest" wsaw:Action="urn:checkUserHasBrowseQueuePermission"/>
             <wsdl:output message="tns:checkUserHasBrowseQueuePermissionResponse" wsaw:Action="urn:checkUserHasBrowseQueuePermissionResponse"/>
             <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasBrowseQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
-            <wsdl:input message="tns:checkUserHasBrowseMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasBrowseMessagesInDLCPermission"/>
-            <wsdl:output message="tns:checkUserHasBrowseMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasBrowseMessagesInDLCPermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasBrowseMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="checkCurrentUserHasPublishPermission">
+            <wsdl:input message="tns:checkCurrentUserHasPublishPermissionRequest" wsaw:Action="urn:checkCurrentUserHasPublishPermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasPublishPermissionResponse" wsaw:Action="urn:checkCurrentUserHasPublishPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasPublishPermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
-            <wsdl:input message="tns:checkUserHasDeleteMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasDeleteMessagesInDLCPermission"/>
-            <wsdl:output message="tns:checkUserHasDeleteMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasDeleteMessagesInDLCPermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasDeleteMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
+            <wsdl:input message="tns:checkCurrentUserHasPurgeQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasPurgeQueuePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasPurgeQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasPurgeQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasPurgeQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
         <wsdl:operation name="getDLCQueue">
             <wsdl:input message="tns:getDLCQueueRequest" wsaw:Action="urn:getDLCQueue"/>
             <wsdl:output message="tns:getDLCQueueResponse" wsaw:Action="urn:getDLCQueueResponse"/>
             <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getDLCQueueAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasDeleteQueuePermission">
-            <wsdl:input message="tns:checkUserHasDeleteQueuePermissionRequest" wsaw:Action="urn:checkUserHasDeleteQueuePermission"/>
-            <wsdl:output message="tns:checkUserHasDeleteQueuePermissionResponse" wsaw:Action="urn:checkUserHasDeleteQueuePermissionResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasDeleteQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
+            <wsdl:input message="tns:checkUserHasDeleteMessagesInDLCPermissionRequest" wsaw:Action="urn:checkUserHasDeleteMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkUserHasDeleteMessagesInDLCPermissionResponse" wsaw:Action="urn:checkUserHasDeleteMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasDeleteMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueueWithDifferentDestination">
-            <wsdl:input message="tns:restoreMessagesFromDeadLetterQueueWithDifferentDestinationRequest" wsaw:Action="urn:restoreMessagesFromDeadLetterQueueWithDifferentDestination"/>
-            <wsdl:output message="tns:restoreMessagesFromDeadLetterQueueWithDifferentDestinationResponse" wsaw:Action="urn:restoreMessagesFromDeadLetterQueueWithDifferentDestinationResponse"/>
-            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:restoreMessagesFromDeadLetterQueueWithDifferentDestinationAndesAdminServiceBrokerManagerAdminException"/>
+        <wsdl:operation name="getNumberOfMessagesInDLCForQueue">
+            <wsdl:input message="tns:getNumberOfMessagesInDLCForQueueRequest" wsaw:Action="urn:getNumberOfMessagesInDLCForQueue"/>
+            <wsdl:output message="tns:getNumberOfMessagesInDLCForQueueResponse" wsaw:Action="urn:getNumberOfMessagesInDLCForQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getNumberOfMessagesInDLCForQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="rerouteSelectedMessagesFromDeadLetterChannel">
+            <wsdl:input message="tns:rerouteSelectedMessagesFromDeadLetterChannelRequest" wsaw:Action="urn:rerouteSelectedMessagesFromDeadLetterChannel"/>
+            <wsdl:output message="tns:rerouteSelectedMessagesFromDeadLetterChannelResponse" wsaw:Action="urn:rerouteSelectedMessagesFromDeadLetterChannelResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:rerouteSelectedMessagesFromDeadLetterChannelAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
+            <wsdl:input message="tns:checkCurrentUserHasRerouteMessagesInDLCPermissionRequest" wsaw:Action="urn:checkCurrentUserHasRerouteMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasRerouteMessagesInDLCPermissionResponse" wsaw:Action="urn:checkCurrentUserHasRerouteMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasRerouteMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="restoreSelectedMessagesFromDeadLetterChannel">
+            <wsdl:input message="tns:restoreSelectedMessagesFromDeadLetterChannelRequest" wsaw:Action="urn:restoreSelectedMessagesFromDeadLetterChannel"/>
+            <wsdl:output message="tns:restoreSelectedMessagesFromDeadLetterChannelResponse" wsaw:Action="urn:restoreSelectedMessagesFromDeadLetterChannelResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:restoreSelectedMessagesFromDeadLetterChannelAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getFilteredSubscriptions">
+            <wsdl:input message="tns:getFilteredSubscriptionsRequest" wsaw:Action="urn:getFilteredSubscriptions"/>
+            <wsdl:output message="tns:getFilteredSubscriptionsResponse" wsaw:Action="urn:getFilteredSubscriptionsResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getFilteredSubscriptionsAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
+            <wsdl:input message="tns:checkCurrentUserHasRestoreMessagesInDLCPermissionRequest" wsaw:Action="urn:checkCurrentUserHasRestoreMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasRestoreMessagesInDLCPermissionResponse" wsaw:Action="urn:checkCurrentUserHasRestoreMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasRestoreMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="updatePermission">
+            <wsdl:input message="tns:updatePermissionRequest" wsaw:Action="urn:updatePermission"/>
+            <wsdl:output message="tns:updatePermissionResponse" wsaw:Action="urn:updatePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:updatePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPublishPermission">
+            <wsdl:input message="tns:checkUserHasPublishPermissionRequest" wsaw:Action="urn:checkUserHasPublishPermission"/>
+            <wsdl:output message="tns:checkUserHasPublishPermissionResponse" wsaw:Action="urn:checkUserHasPublishPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkUserHasPublishPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasBrowseMessagesInDLCPermission">
+            <wsdl:input message="tns:checkCurrentUserHasBrowseMessagesInDLCPermissionRequest" wsaw:Action="urn:checkCurrentUserHasBrowseMessagesInDLCPermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasBrowseMessagesInDLCPermissionResponse" wsaw:Action="urn:checkCurrentUserHasBrowseMessagesInDLCPermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasBrowseMessagesInDLCPermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="closeSubscription">
+            <wsdl:input message="tns:closeSubscriptionRequest" wsaw:Action="urn:closeSubscription"/>
+            <wsdl:output message="tns:closeSubscriptionResponse" wsaw:Action="urn:closeSubscriptionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:closeSubscriptionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="sendMessage">
+            <wsdl:input message="tns:sendMessageRequest" wsaw:Action="urn:sendMessage"/>
+            <wsdl:output message="tns:sendMessageResponse" wsaw:Action="urn:sendMessageResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:sendMessageAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
+            <wsdl:input message="tns:deleteMessagesFromDeadLetterQueueRequest" wsaw:Action="urn:deleteMessagesFromDeadLetterQueue"/>
+            <wsdl:output message="tns:deleteMessagesFromDeadLetterQueueResponse" wsaw:Action="urn:deleteMessagesFromDeadLetterQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteMessagesFromDeadLetterQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="deleteTopicFromRegistry">
+            <wsdl:input message="tns:deleteTopicFromRegistryRequest" wsaw:Action="urn:deleteTopicFromRegistry"/>
+            <wsdl:output message="tns:deleteTopicFromRegistryResponse" wsaw:Action="urn:deleteTopicFromRegistryResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteTopicFromRegistryAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
+            <wsdl:input message="tns:checkCurrentUserHasDeleteQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasDeleteQueuePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasDeleteQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasDeleteQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasDeleteQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getQueueRolePermission">
+            <wsdl:input message="tns:getQueueRolePermissionRequest" wsaw:Action="urn:getQueueRolePermission"/>
+            <wsdl:output message="tns:getQueueRolePermissionResponse" wsaw:Action="urn:getQueueRolePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:getQueueRolePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
+            <wsdl:input message="tns:checkCurrentUserHasAddQueuePermissionRequest" wsaw:Action="urn:checkCurrentUserHasAddQueuePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasAddQueuePermissionResponse" wsaw:Action="urn:checkCurrentUserHasAddQueuePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasAddQueuePermissionAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="deleteQueue">
+            <wsdl:input message="tns:deleteQueueRequest" wsaw:Action="urn:deleteQueue"/>
+            <wsdl:output message="tns:deleteQueueResponse" wsaw:Action="urn:deleteQueueResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:deleteQueueAndesAdminServiceBrokerManagerAdminException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
+            <wsdl:input message="tns:checkCurrentUserHasTopicSubscriptionClosePermissionRequest" wsaw:Action="urn:checkCurrentUserHasTopicSubscriptionClosePermission"/>
+            <wsdl:output message="tns:checkCurrentUserHasTopicSubscriptionClosePermissionResponse" wsaw:Action="urn:checkCurrentUserHasTopicSubscriptionClosePermissionResponse"/>
+            <wsdl:fault message="tns:AndesAdminServiceBrokerManagerAdminException" name="AndesAdminServiceBrokerManagerAdminException" wsaw:Action="urn:checkCurrentUserHasTopicSubscriptionClosePermissionAndesAdminServiceBrokerManagerAdminException"/>
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="AndesAdminServiceSoap11Binding" type="tns:AndesAdminServicePortType">
         <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
-        <wsdl:operation name="addQueueAndAssignPermission">
-            <soap:operation soapAction="urn:addQueueAndAssignPermission" style="document"/>
+        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkUserHasBrowseMessagesInDLCPermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1236,8 +1290,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
-            <soap:operation soapAction="urn:deleteMessagesFromDeadLetterQueue" style="document"/>
+        <wsdl:operation name="getMessageCount">
+            <soap:operation soapAction="urn:getMessageCount" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1248,8 +1302,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getAllQueues">
-            <soap:operation soapAction="urn:getAllQueues" style="document"/>
+        <wsdl:operation name="getMessagesInDLCForQueue">
+            <soap:operation soapAction="urn:getMessagesInDLCForQueue" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1260,8 +1314,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getMessageInDLCForQueue">
-            <soap:operation soapAction="urn:getMessageInDLCForQueue" style="document"/>
+        <wsdl:operation name="dumpMessageStatus">
+            <soap:operation soapAction="urn:dumpMessageStatus" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1272,8 +1326,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getFilteredSubscriptions">
-            <soap:operation soapAction="urn:getFilteredSubscriptions" style="document"/>
+        <wsdl:operation name="getUserRoles">
+            <soap:operation soapAction="urn:getUserRoles" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1284,8 +1338,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
-            <soap:operation soapAction="urn:checkCurrentUserHasTopicSubscriptionClosePermission" style="document"/>
+        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasBrowseQueuePermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1296,8 +1350,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
-            <soap:operation soapAction="urn:checkCurrentUserHasDeleteQueuePermission" style="document"/>
+        <wsdl:operation name="rerouteAllMessagesFromDeadLetterChannelForQueue">
+            <soap:operation soapAction="urn:rerouteAllMessagesFromDeadLetterChannelForQueue" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1308,44 +1362,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="updatePermission">
-            <soap:operation soapAction="urn:updatePermission" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="sendMessage">
-            <soap:operation soapAction="urn:sendMessage" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="deleteTopicFromRegistry">
-            <soap:operation soapAction="urn:deleteTopicFromRegistry" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueue">
-            <soap:operation soapAction="urn:restoreMessagesFromDeadLetterQueue" style="document"/>
+        <wsdl:operation name="getPendingMessageCount">
+            <soap:operation soapAction="urn:getPendingMessageCount" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1368,80 +1386,68 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
-            <soap:operation soapAction="urn:checkCurrentUserHasPurgeQueuePermission" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="purgeMessagesOfQueue">
-            <soap:operation soapAction="urn:purgeMessagesOfQueue" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
-            <soap:operation soapAction="urn:getTotalSubscriptionCountForSearchResult" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasPublishPermission">
-            <soap:operation soapAction="urn:checkCurrentUserHasPublishPermission" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
-            <soap:operation soapAction="urn:checkCurrentUserHasRerouteMessagesInDLCPermission" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="browseQueue">
-            <soap:operation soapAction="urn:browseQueue" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
         <wsdl:operation name="checkCurrentUserHasDeleteMessagesInDLCPermission">
             <soap:operation soapAction="urn:checkCurrentUserHasDeleteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkUserHasRerouteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getAllSubscriptions">
+            <soap:operation soapAction="urn:getAllSubscriptions" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getAllQueues">
+            <soap:operation soapAction="urn:getAllQueues" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteQueuePermission">
+            <soap:operation soapAction="urn:checkUserHasDeleteQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageMetadataInDeadLetterChannel">
+            <soap:operation soapAction="urn:getMessageMetadataInDeadLetterChannel" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1488,8 +1494,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="deleteQueue">
-            <soap:operation soapAction="urn:deleteQueue" style="document"/>
+        <wsdl:operation name="addQueueAndAssignPermission">
+            <soap:operation soapAction="urn:addQueueAndAssignPermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1500,8 +1506,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getQueueRolePermission">
-            <soap:operation soapAction="urn:getQueueRolePermission" style="document"/>
+        <wsdl:operation name="browseQueue">
+            <soap:operation soapAction="urn:browseQueue" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1512,8 +1518,32 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
-            <soap:operation soapAction="urn:checkUserHasRestoreMessagesInDLCPermission" style="document"/>
+        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
+            <soap:operation soapAction="urn:getTotalSubscriptionCountForSearchResult" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="purgeMessagesOfQueue">
+            <soap:operation soapAction="urn:purgeMessagesOfQueue" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPurgeQueuePermission">
+            <soap:operation soapAction="urn:checkUserHasPurgeQueuePermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1536,32 +1566,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getMessageCount">
-            <soap:operation soapAction="urn:getMessageCount" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getUserRoles">
-            <soap:operation soapAction="urn:getUserRoles" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
-            <soap:operation soapAction="urn:checkCurrentUserHasAddQueuePermission" style="document"/>
+        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkUserHasRestoreMessagesInDLCPermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1584,8 +1590,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasPublishPermission">
-            <soap:operation soapAction="urn:checkUserHasPublishPermission" style="document"/>
+        <wsdl:operation name="getQueueByName">
+            <soap:operation soapAction="urn:getQueueByName" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1596,8 +1602,56 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getPendingMessageCount">
-            <soap:operation soapAction="urn:getPendingMessageCount" style="document"/>
+        <wsdl:operation name="checkUserHasBrowseQueuePermission">
+            <soap:operation soapAction="urn:checkUserHasBrowseQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPublishPermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasPublishPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasPurgeQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getDLCQueue">
+            <soap:operation soapAction="urn:getDLCQueue" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkUserHasDeleteMessagesInDLCPermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1620,8 +1674,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getAllSubscriptions">
-            <soap:operation soapAction="urn:getAllSubscriptions" style="document"/>
+        <wsdl:operation name="rerouteSelectedMessagesFromDeadLetterChannel">
+            <soap:operation soapAction="urn:rerouteSelectedMessagesFromDeadLetterChannel" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1632,8 +1686,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="dumpMessageStatus">
-            <soap:operation soapAction="urn:dumpMessageStatus" style="document"/>
+        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasRerouteMessagesInDLCPermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1644,8 +1698,56 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasPurgeQueuePermission">
-            <soap:operation soapAction="urn:checkUserHasPurgeQueuePermission" style="document"/>
+        <wsdl:operation name="restoreSelectedMessagesFromDeadLetterChannel">
+            <soap:operation soapAction="urn:restoreSelectedMessagesFromDeadLetterChannel" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getFilteredSubscriptions">
+            <soap:operation soapAction="urn:getFilteredSubscriptions" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasRestoreMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="updatePermission">
+            <soap:operation soapAction="urn:updatePermission" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPublishPermission">
+            <soap:operation soapAction="urn:checkUserHasPublishPermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1680,8 +1782,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
-            <soap:operation soapAction="urn:checkUserHasRerouteMessagesInDLCPermission" style="document"/>
+        <wsdl:operation name="sendMessage">
+            <soap:operation soapAction="urn:sendMessage" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1692,8 +1794,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
-            <soap:operation soapAction="urn:checkCurrentUserHasBrowseQueuePermission" style="document"/>
+        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
+            <soap:operation soapAction="urn:deleteMessagesFromDeadLetterQueue" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1704,8 +1806,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getQueueByName">
-            <soap:operation soapAction="urn:getQueueByName" style="document"/>
+        <wsdl:operation name="deleteTopicFromRegistry">
+            <soap:operation soapAction="urn:deleteTopicFromRegistry" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1716,8 +1818,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
-            <soap:operation soapAction="urn:checkCurrentUserHasRestoreMessagesInDLCPermission" style="document"/>
+        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasDeleteQueuePermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1728,8 +1830,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasBrowseQueuePermission">
-            <soap:operation soapAction="urn:checkUserHasBrowseQueuePermission" style="document"/>
+        <wsdl:operation name="getQueueRolePermission">
+            <soap:operation soapAction="urn:getQueueRolePermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1740,8 +1842,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
-            <soap:operation soapAction="urn:checkUserHasBrowseMessagesInDLCPermission" style="document"/>
+        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasAddQueuePermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1752,8 +1854,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
-            <soap:operation soapAction="urn:checkUserHasDeleteMessagesInDLCPermission" style="document"/>
+        <wsdl:operation name="deleteQueue">
+            <soap:operation soapAction="urn:deleteQueue" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1764,32 +1866,8 @@
                 <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getDLCQueue">
-            <soap:operation soapAction="urn:getDLCQueue" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="checkUserHasDeleteQueuePermission">
-            <soap:operation soapAction="urn:checkUserHasDeleteQueuePermission" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueueWithDifferentDestination">
-            <soap:operation soapAction="urn:restoreMessagesFromDeadLetterQueueWithDifferentDestination" style="document"/>
+        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
+            <soap:operation soapAction="urn:checkCurrentUserHasTopicSubscriptionClosePermission" style="document"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>
@@ -1803,8 +1881,8 @@
     </wsdl:binding>
     <wsdl:binding name="AndesAdminServiceSoap12Binding" type="tns:AndesAdminServicePortType">
         <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
-        <wsdl:operation name="addQueueAndAssignPermission">
-            <soap12:operation soapAction="urn:addQueueAndAssignPermission" style="document"/>
+        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkUserHasBrowseMessagesInDLCPermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -1815,8 +1893,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
-            <soap12:operation soapAction="urn:deleteMessagesFromDeadLetterQueue" style="document"/>
+        <wsdl:operation name="getMessageCount">
+            <soap12:operation soapAction="urn:getMessageCount" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -1827,8 +1905,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getAllQueues">
-            <soap12:operation soapAction="urn:getAllQueues" style="document"/>
+        <wsdl:operation name="getMessagesInDLCForQueue">
+            <soap12:operation soapAction="urn:getMessagesInDLCForQueue" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -1839,8 +1917,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getMessageInDLCForQueue">
-            <soap12:operation soapAction="urn:getMessageInDLCForQueue" style="document"/>
+        <wsdl:operation name="dumpMessageStatus">
+            <soap12:operation soapAction="urn:dumpMessageStatus" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -1851,8 +1929,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getFilteredSubscriptions">
-            <soap12:operation soapAction="urn:getFilteredSubscriptions" style="document"/>
+        <wsdl:operation name="getUserRoles">
+            <soap12:operation soapAction="urn:getUserRoles" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -1863,8 +1941,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
-            <soap12:operation soapAction="urn:checkCurrentUserHasTopicSubscriptionClosePermission" style="document"/>
+        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasBrowseQueuePermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -1875,8 +1953,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
-            <soap12:operation soapAction="urn:checkCurrentUserHasDeleteQueuePermission" style="document"/>
+        <wsdl:operation name="rerouteAllMessagesFromDeadLetterChannelForQueue">
+            <soap12:operation soapAction="urn:rerouteAllMessagesFromDeadLetterChannelForQueue" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -1887,44 +1965,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="updatePermission">
-            <soap12:operation soapAction="urn:updatePermission" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="sendMessage">
-            <soap12:operation soapAction="urn:sendMessage" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="deleteTopicFromRegistry">
-            <soap12:operation soapAction="urn:deleteTopicFromRegistry" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueue">
-            <soap12:operation soapAction="urn:restoreMessagesFromDeadLetterQueue" style="document"/>
+        <wsdl:operation name="getPendingMessageCount">
+            <soap12:operation soapAction="urn:getPendingMessageCount" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -1947,80 +1989,68 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
-            <soap12:operation soapAction="urn:checkCurrentUserHasPurgeQueuePermission" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="purgeMessagesOfQueue">
-            <soap12:operation soapAction="urn:purgeMessagesOfQueue" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
-            <soap12:operation soapAction="urn:getTotalSubscriptionCountForSearchResult" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasPublishPermission">
-            <soap12:operation soapAction="urn:checkCurrentUserHasPublishPermission" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
-            <soap12:operation soapAction="urn:checkCurrentUserHasRerouteMessagesInDLCPermission" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="browseQueue">
-            <soap12:operation soapAction="urn:browseQueue" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
         <wsdl:operation name="checkCurrentUserHasDeleteMessagesInDLCPermission">
             <soap12:operation soapAction="urn:checkCurrentUserHasDeleteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkUserHasRerouteMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getAllSubscriptions">
+            <soap12:operation soapAction="urn:getAllSubscriptions" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getAllQueues">
+            <soap12:operation soapAction="urn:getAllQueues" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteQueuePermission">
+            <soap12:operation soapAction="urn:checkUserHasDeleteQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageMetadataInDeadLetterChannel">
+            <soap12:operation soapAction="urn:getMessageMetadataInDeadLetterChannel" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2067,8 +2097,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="deleteQueue">
-            <soap12:operation soapAction="urn:deleteQueue" style="document"/>
+        <wsdl:operation name="addQueueAndAssignPermission">
+            <soap12:operation soapAction="urn:addQueueAndAssignPermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2079,8 +2109,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getQueueRolePermission">
-            <soap12:operation soapAction="urn:getQueueRolePermission" style="document"/>
+        <wsdl:operation name="browseQueue">
+            <soap12:operation soapAction="urn:browseQueue" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2091,8 +2121,32 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
-            <soap12:operation soapAction="urn:checkUserHasRestoreMessagesInDLCPermission" style="document"/>
+        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
+            <soap12:operation soapAction="urn:getTotalSubscriptionCountForSearchResult" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="purgeMessagesOfQueue">
+            <soap12:operation soapAction="urn:purgeMessagesOfQueue" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPurgeQueuePermission">
+            <soap12:operation soapAction="urn:checkUserHasPurgeQueuePermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2115,32 +2169,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getMessageCount">
-            <soap12:operation soapAction="urn:getMessageCount" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="getUserRoles">
-            <soap12:operation soapAction="urn:getUserRoles" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
-            <soap12:operation soapAction="urn:checkCurrentUserHasAddQueuePermission" style="document"/>
+        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkUserHasRestoreMessagesInDLCPermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2163,8 +2193,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasPublishPermission">
-            <soap12:operation soapAction="urn:checkUserHasPublishPermission" style="document"/>
+        <wsdl:operation name="getQueueByName">
+            <soap12:operation soapAction="urn:getQueueByName" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2175,8 +2205,56 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getPendingMessageCount">
-            <soap12:operation soapAction="urn:getPendingMessageCount" style="document"/>
+        <wsdl:operation name="checkUserHasBrowseQueuePermission">
+            <soap12:operation soapAction="urn:checkUserHasBrowseQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPublishPermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasPublishPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasPurgeQueuePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getDLCQueue">
+            <soap12:operation soapAction="urn:getDLCQueue" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkUserHasDeleteMessagesInDLCPermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2199,8 +2277,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getAllSubscriptions">
-            <soap12:operation soapAction="urn:getAllSubscriptions" style="document"/>
+        <wsdl:operation name="rerouteSelectedMessagesFromDeadLetterChannel">
+            <soap12:operation soapAction="urn:rerouteSelectedMessagesFromDeadLetterChannel" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2211,8 +2289,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="dumpMessageStatus">
-            <soap12:operation soapAction="urn:dumpMessageStatus" style="document"/>
+        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasRerouteMessagesInDLCPermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2223,8 +2301,56 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasPurgeQueuePermission">
-            <soap12:operation soapAction="urn:checkUserHasPurgeQueuePermission" style="document"/>
+        <wsdl:operation name="restoreSelectedMessagesFromDeadLetterChannel">
+            <soap12:operation soapAction="urn:restoreSelectedMessagesFromDeadLetterChannel" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getFilteredSubscriptions">
+            <soap12:operation soapAction="urn:getFilteredSubscriptions" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasRestoreMessagesInDLCPermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="updatePermission">
+            <soap12:operation soapAction="urn:updatePermission" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
+                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPublishPermission">
+            <soap12:operation soapAction="urn:checkUserHasPublishPermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2259,8 +2385,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
-            <soap12:operation soapAction="urn:checkUserHasRerouteMessagesInDLCPermission" style="document"/>
+        <wsdl:operation name="sendMessage">
+            <soap12:operation soapAction="urn:sendMessage" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2271,8 +2397,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
-            <soap12:operation soapAction="urn:checkCurrentUserHasBrowseQueuePermission" style="document"/>
+        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
+            <soap12:operation soapAction="urn:deleteMessagesFromDeadLetterQueue" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2283,8 +2409,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getQueueByName">
-            <soap12:operation soapAction="urn:getQueueByName" style="document"/>
+        <wsdl:operation name="deleteTopicFromRegistry">
+            <soap12:operation soapAction="urn:deleteTopicFromRegistry" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2295,8 +2421,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
-            <soap12:operation soapAction="urn:checkCurrentUserHasRestoreMessagesInDLCPermission" style="document"/>
+        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasDeleteQueuePermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2307,8 +2433,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasBrowseQueuePermission">
-            <soap12:operation soapAction="urn:checkUserHasBrowseQueuePermission" style="document"/>
+        <wsdl:operation name="getQueueRolePermission">
+            <soap12:operation soapAction="urn:getQueueRolePermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2319,8 +2445,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
-            <soap12:operation soapAction="urn:checkUserHasBrowseMessagesInDLCPermission" style="document"/>
+        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasAddQueuePermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2331,8 +2457,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
-            <soap12:operation soapAction="urn:checkUserHasDeleteMessagesInDLCPermission" style="document"/>
+        <wsdl:operation name="deleteQueue">
+            <soap12:operation soapAction="urn:deleteQueue" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2343,32 +2469,8 @@
                 <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="getDLCQueue">
-            <soap12:operation soapAction="urn:getDLCQueue" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="checkUserHasDeleteQueuePermission">
-            <soap12:operation soapAction="urn:checkUserHasDeleteQueuePermission" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:output>
-                <soap12:body use="literal"/>
-            </wsdl:output>
-            <wsdl:fault name="AndesAdminServiceBrokerManagerAdminException">
-                <soap12:fault use="literal" name="AndesAdminServiceBrokerManagerAdminException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueueWithDifferentDestination">
-            <soap12:operation soapAction="urn:restoreMessagesFromDeadLetterQueueWithDifferentDestination" style="document"/>
+        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
+            <soap12:operation soapAction="urn:checkCurrentUserHasTopicSubscriptionClosePermission" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
@@ -2382,8 +2484,8 @@
     </wsdl:binding>
     <wsdl:binding name="AndesAdminServiceHttpBinding" type="tns:AndesAdminServicePortType">
         <http:binding verb="POST"/>
-        <wsdl:operation name="addQueueAndAssignPermission">
-            <http:operation location="addQueueAndAssignPermission"/>
+        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
+            <http:operation location="checkUserHasBrowseMessagesInDLCPermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2391,8 +2493,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
-            <http:operation location="deleteMessagesFromDeadLetterQueue"/>
+        <wsdl:operation name="getMessageCount">
+            <http:operation location="getMessageCount"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2400,8 +2502,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getAllQueues">
-            <http:operation location="getAllQueues"/>
+        <wsdl:operation name="getMessagesInDLCForQueue">
+            <http:operation location="getMessagesInDLCForQueue"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2409,8 +2511,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getMessageInDLCForQueue">
-            <http:operation location="getMessageInDLCForQueue"/>
+        <wsdl:operation name="dumpMessageStatus">
+            <http:operation location="dumpMessageStatus"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2418,8 +2520,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getFilteredSubscriptions">
-            <http:operation location="getFilteredSubscriptions"/>
+        <wsdl:operation name="getUserRoles">
+            <http:operation location="getUserRoles"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2427,8 +2529,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
-            <http:operation location="checkCurrentUserHasTopicSubscriptionClosePermission"/>
+        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
+            <http:operation location="checkCurrentUserHasBrowseQueuePermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2436,8 +2538,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
-            <http:operation location="checkCurrentUserHasDeleteQueuePermission"/>
+        <wsdl:operation name="rerouteAllMessagesFromDeadLetterChannelForQueue">
+            <http:operation location="rerouteAllMessagesFromDeadLetterChannelForQueue"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2445,35 +2547,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="updatePermission">
-            <http:operation location="updatePermission"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="sendMessage">
-            <http:operation location="sendMessage"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="deleteTopicFromRegistry">
-            <http:operation location="deleteTopicFromRegistry"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueue">
-            <http:operation location="restoreMessagesFromDeadLetterQueue"/>
+        <wsdl:operation name="getPendingMessageCount">
+            <http:operation location="getPendingMessageCount"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2490,62 +2565,53 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
-            <http:operation location="checkCurrentUserHasPurgeQueuePermission"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="purgeMessagesOfQueue">
-            <http:operation location="purgeMessagesOfQueue"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
-            <http:operation location="getTotalSubscriptionCountForSearchResult"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasPublishPermission">
-            <http:operation location="checkCurrentUserHasPublishPermission"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
-            <http:operation location="checkCurrentUserHasRerouteMessagesInDLCPermission"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="browseQueue">
-            <http:operation location="browseQueue"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
         <wsdl:operation name="checkCurrentUserHasDeleteMessagesInDLCPermission">
             <http:operation location="checkCurrentUserHasDeleteMessagesInDLCPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
+            <http:operation location="checkUserHasRerouteMessagesInDLCPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getAllSubscriptions">
+            <http:operation location="getAllSubscriptions"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getAllQueues">
+            <http:operation location="getAllQueues"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteQueuePermission">
+            <http:operation location="checkUserHasDeleteQueuePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getMessageMetadataInDeadLetterChannel">
+            <http:operation location="getMessageMetadataInDeadLetterChannel"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2580,8 +2646,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="deleteQueue">
-            <http:operation location="deleteQueue"/>
+        <wsdl:operation name="addQueueAndAssignPermission">
+            <http:operation location="addQueueAndAssignPermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2589,8 +2655,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getQueueRolePermission">
-            <http:operation location="getQueueRolePermission"/>
+        <wsdl:operation name="browseQueue">
+            <http:operation location="browseQueue"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2598,8 +2664,26 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
-            <http:operation location="checkUserHasRestoreMessagesInDLCPermission"/>
+        <wsdl:operation name="getTotalSubscriptionCountForSearchResult">
+            <http:operation location="getTotalSubscriptionCountForSearchResult"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="purgeMessagesOfQueue">
+            <http:operation location="purgeMessagesOfQueue"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPurgeQueuePermission">
+            <http:operation location="checkUserHasPurgeQueuePermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2616,26 +2700,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getMessageCount">
-            <http:operation location="getMessageCount"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="getUserRoles">
-            <http:operation location="getUserRoles"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
-            <http:operation location="checkCurrentUserHasAddQueuePermission"/>
+        <wsdl:operation name="checkUserHasRestoreMessagesInDLCPermission">
+            <http:operation location="checkUserHasRestoreMessagesInDLCPermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2652,8 +2718,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasPublishPermission">
-            <http:operation location="checkUserHasPublishPermission"/>
+        <wsdl:operation name="getQueueByName">
+            <http:operation location="getQueueByName"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2661,8 +2727,44 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getPendingMessageCount">
-            <http:operation location="getPendingMessageCount"/>
+        <wsdl:operation name="checkUserHasBrowseQueuePermission">
+            <http:operation location="checkUserHasBrowseQueuePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPublishPermission">
+            <http:operation location="checkCurrentUserHasPublishPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasPurgeQueuePermission">
+            <http:operation location="checkCurrentUserHasPurgeQueuePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getDLCQueue">
+            <http:operation location="getDLCQueue"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
+            <http:operation location="checkUserHasDeleteMessagesInDLCPermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2679,8 +2781,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getAllSubscriptions">
-            <http:operation location="getAllSubscriptions"/>
+        <wsdl:operation name="rerouteSelectedMessagesFromDeadLetterChannel">
+            <http:operation location="rerouteSelectedMessagesFromDeadLetterChannel"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2688,8 +2790,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="dumpMessageStatus">
-            <http:operation location="dumpMessageStatus"/>
+        <wsdl:operation name="checkCurrentUserHasRerouteMessagesInDLCPermission">
+            <http:operation location="checkCurrentUserHasRerouteMessagesInDLCPermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2697,8 +2799,44 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasPurgeQueuePermission">
-            <http:operation location="checkUserHasPurgeQueuePermission"/>
+        <wsdl:operation name="restoreSelectedMessagesFromDeadLetterChannel">
+            <http:operation location="restoreSelectedMessagesFromDeadLetterChannel"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getFilteredSubscriptions">
+            <http:operation location="getFilteredSubscriptions"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
+            <http:operation location="checkCurrentUserHasRestoreMessagesInDLCPermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="updatePermission">
+            <http:operation location="updatePermission"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="checkUserHasPublishPermission">
+            <http:operation location="checkUserHasPublishPermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2724,8 +2862,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasRerouteMessagesInDLCPermission">
-            <http:operation location="checkUserHasRerouteMessagesInDLCPermission"/>
+        <wsdl:operation name="sendMessage">
+            <http:operation location="sendMessage"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2733,8 +2871,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasBrowseQueuePermission">
-            <http:operation location="checkCurrentUserHasBrowseQueuePermission"/>
+        <wsdl:operation name="deleteMessagesFromDeadLetterQueue">
+            <http:operation location="deleteMessagesFromDeadLetterQueue"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2742,8 +2880,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getQueueByName">
-            <http:operation location="getQueueByName"/>
+        <wsdl:operation name="deleteTopicFromRegistry">
+            <http:operation location="deleteTopicFromRegistry"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2751,8 +2889,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkCurrentUserHasRestoreMessagesInDLCPermission">
-            <http:operation location="checkCurrentUserHasRestoreMessagesInDLCPermission"/>
+        <wsdl:operation name="checkCurrentUserHasDeleteQueuePermission">
+            <http:operation location="checkCurrentUserHasDeleteQueuePermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2760,8 +2898,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasBrowseQueuePermission">
-            <http:operation location="checkUserHasBrowseQueuePermission"/>
+        <wsdl:operation name="getQueueRolePermission">
+            <http:operation location="getQueueRolePermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2769,8 +2907,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasBrowseMessagesInDLCPermission">
-            <http:operation location="checkUserHasBrowseMessagesInDLCPermission"/>
+        <wsdl:operation name="checkCurrentUserHasAddQueuePermission">
+            <http:operation location="checkCurrentUserHasAddQueuePermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2778,8 +2916,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="checkUserHasDeleteMessagesInDLCPermission">
-            <http:operation location="checkUserHasDeleteMessagesInDLCPermission"/>
+        <wsdl:operation name="deleteQueue">
+            <http:operation location="deleteQueue"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2787,26 +2925,8 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="getDLCQueue">
-            <http:operation location="getDLCQueue"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="checkUserHasDeleteQueuePermission">
-            <http:operation location="checkUserHasDeleteQueuePermission"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-            <wsdl:output>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:output>
-        </wsdl:operation>
-        <wsdl:operation name="restoreMessagesFromDeadLetterQueueWithDifferentDestination">
-            <http:operation location="restoreMessagesFromDeadLetterQueueWithDifferentDestination"/>
+        <wsdl:operation name="checkCurrentUserHasTopicSubscriptionClosePermission">
+            <http:operation location="checkCurrentUserHasTopicSubscriptionClosePermission"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -2817,13 +2937,13 @@
     </wsdl:binding>
     <wsdl:service name="AndesAdminService">
         <wsdl:port name="AndesAdminServiceHttpsSoap11Endpoint" binding="tns:AndesAdminServiceSoap11Binding">
-            <soap:address location="https://172.17.0.1:9443/services/AndesAdminService.AndesAdminServiceHttpsSoap11Endpoint/"/>
+            <soap:address location="https://192.168.1.5:9443/services/AndesAdminService.AndesAdminServiceHttpsSoap11Endpoint/"/>
         </wsdl:port>
         <wsdl:port name="AndesAdminServiceHttpsSoap12Endpoint" binding="tns:AndesAdminServiceSoap12Binding">
-            <soap12:address location="https://172.17.0.1:9443/services/AndesAdminService.AndesAdminServiceHttpsSoap12Endpoint/"/>
+            <soap12:address location="https://192.168.1.5:9443/services/AndesAdminService.AndesAdminServiceHttpsSoap12Endpoint/"/>
         </wsdl:port>
         <wsdl:port name="AndesAdminServiceHttpsEndpoint" binding="tns:AndesAdminServiceHttpBinding">
-            <http:address location="https://172.17.0.1:9443/services/AndesAdminService.AndesAdminServiceHttpsEndpoint/"/>
+            <http:address location="https://192.168.1.5:9443/services/AndesAdminService.AndesAdminServiceHttpsEndpoint/"/>
         </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>


### PR DESCRIPTION
provides 2 new Admin services with regard to DLC operations within the server.

1. getMessageMetadataInDeadLetterChannel

     Returns a paginated list of message metadata destined for the targetQueue but currently living in the
     Dead Letter Channel.
     
     @param targetQueue    Name of the destination queue
     @param startMessageId Start point of the queue message id to start reading
     @param pageLimit      Maximum number of messages required in a single response

2. rerouteAllMessagesFromDeadLetterChannelForQueue

	 Move messages destined for the input sourceQueue into a different targetQueue.
	 If the sourceQueue is DLCQueue, all messages in the DLC will be restored to the targetQueue.

	 @param sourceQueue       Name of the source queue
	 @param targetQueue       Name of the target queue.
	 @param internalBatchSize even with this method, the MB server will internally read messages in DLC in batches,
	                          and simulate each batch as a new message list to the targetQueue. "internalBatchSize"
	                          controls the number of messages processed in a single batch internally.