### PR TITLE
Fix MB-1935

### DIFF
--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_messages_list.jsp
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_messages_list.jsp
@@ -466,6 +466,7 @@
                         <%=StringEscapeUtils.escapeHtml(messageContent[0])%>
                         <!-- This is converted to a POST to avoid message length eating up the URI request length. -->
                         <form name="msgViewForm<%=contentDisplayID%>" method="POST" action="message_content.jsp">
+                            <input type="hidden" name="<csrf:tokenname/>" value="<csrf:tokenvalue/>" />
                             <input type="hidden" name="message" value="<%=StringEscapeUtils.escapeHtml(messageContent[1])%>" />
                             <a href="javascript:document.msgViewForm<%=contentDisplayID%>.submit()">&nbsp;&nbsp;&nbsp;more..</a>
                         </form>


### PR DESCRIPTION
This issue related to view message content of DLC. 'more..' link submit a POST request to backend but CSRF token missing on the last record. As a result, it ends up in forbidden page. The fix is to add CSRF token as hidden value in the form.