### PR TITLE
Change deployment configurations

### DIFF
--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
@@ -102,7 +102,7 @@ public class BrokerServiceComponent {
         /**
          * Starts the server in default mode
          */
-        DEFAULT;
+        CLUSTERED;
 
     }
 
@@ -134,7 +134,7 @@ public class BrokerServiceComponent {
                 // going to consider it in standalone mode
                 AndesContext.getInstance().setClusteringEnabled(false);
                 this.startAndesBroker(context);
-            } else if (mode.equalsIgnoreCase(Modes.DEFAULT.name())) {
+            } else if (mode.equalsIgnoreCase(Modes.CLUSTERED.name())) {
                 //TODO this flow would change once clustering would be introduced
                 //TODO using RequiredCapabilityListener would be an option
                 // Start broker in HA mode

--- a/features/org.wso2.carbon.business.messaging.core.feature/resources/conf/broker.xml
+++ b/features/org.wso2.carbon.business.messaging.core.feature/resources/conf/broker.xml
@@ -568,16 +568,13 @@ This file is ciphertool compliant. Refer PRODUCT_HOME/repository/conf/security/c
     </recovery>
 
     <!--
-        Specifies the deployment mode for the broker node (and cluster). Possible values {default, standalone}.
+        Specifies the deployment mode for the broker node (and cluster). Possible values {standalone, clustered}.
 
-        default - Broker node will decide to run HA (master/slave) or fully distributed mode. Decision is taken based
-                  on the node has a clustering mechanism enabled or not. If the node is not configured to join a cluster
-                  it will run in HA mode (refer to axis2.xml for more information). If the node can join a cluster it
-                  will start in fully clustered mode.
+        standalone - This is the simplest mode a broker can be started. The node will assume that message store is not
+                     shared with another node. Therefore it will not try to coordinate with other nodes (possibly
+                     non-existent) to provide HA.
 
-        standalone - This is the simplest mode a broker can be started. Node will assume datastore is not shared with
-                     another node. Therefore it will not try to coordinate with other nodes (possibly non-existent) to
-                     provide HA or clustering.
+        clustered - Broker node will run in HA mode (active/passive).
     -->
     <deployment>
         <mode>standalone</mode>

--- a/features/org.wso2.carbon.business.messaging.core.feature/src/main/resources/conf/broker.xml
+++ b/features/org.wso2.carbon.business.messaging.core.feature/src/main/resources/conf/broker.xml
@@ -568,16 +568,13 @@ This file is ciphertool compliant. Refer PRODUCT_HOME/repository/conf/security/c
     </recovery>
 
     <!--
-        Specifies the deployment mode for the broker node (and cluster). Possible values {default, standalone}.
+        Specifies the deployment mode for the broker node (and cluster). Possible values {standalone, clustered}.
 
-        default - Broker node will decide to run HA (master/slave) or fully distributed mode. Decision is taken based
-                  on the node has a clustering mechanism enabled or not. If the node is not configured to join a cluster
-                  it will run in HA mode (refer to axis2.xml for more information). If the node can join a cluster it
-                  will start in fully clustered mode.
+        standalone - This is the simplest mode a broker can be started. The node will assume that message store is not
+                     shared with another node. Therefore it will not try to coordinate with other nodes (possibly
+                     non-existent) to provide HA.
 
-        standalone - This is the simplest mode a broker can be started. Node will assume datastore is not shared with
-                     another node. Therefore it will not try to coordinate with other nodes (possibly non-existent) to
-                     provide HA or clustering.
+        clustered - Broker node will run in HA mode (active/passive).
     -->
     <deployment>
         <mode>standalone</mode>


### PR DESCRIPTION
We now have two options for "deployment/mode". They are,

- **standalone** - This is the simplest mode a broker can be started. The node will assume that message store is not shared with another node. Therefore it will not try to coordinate with other nodes (possibly non-existent) to provide HA. This is the default configuration used.
- **clustered** - Broker node will run in HA mode (active/passive).