### PR TITLE
Add authentication interface support for MB4. 

### DIFF
--- a/components/org.wso2.carbon.business.messaging.core/pom.xml
+++ b/components/org.wso2.carbon.business.messaging.core/pom.xml
@@ -17,7 +17,8 @@
   ~  under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.wso2.carbon.business.messaging</groupId>

--- a/components/org.wso2.carbon.business.messaging.core/pom.xml
+++ b/components/org.wso2.carbon.business.messaging.core/pom.xml
@@ -95,17 +95,22 @@
     </dependencies>
 
     <properties>
+        <bundle.activator>org.wso2.carbon.business.messaging.core.internal.BrokerCoreBundleActivator</bundle.activator>
         <private.package>org.wso2.carbon.business.messaging.core.internal</private.package>
         <export.package>
             !org.wso2.carbon.business.messaging.core.internal,
             org.wso2.carbon.business.messaging.core.*;version="${carbon.business.messaging.version}"
         </export.package>
         <import.package>
-            org.wso2.andes.configuration.*,
+            org.wso2.andes.*,
             org.apache.commons.*,
             org.wso2.carbon.utils.*;version="${carbon.utils.package.import.version.range}",
             *;resolution:=optional
         </import.package>
+        <carbon.component>
+            startup.listener;componentName="business-messaging-auth-mgt";requiredService="org.wso2.carbon.business.messaging.core.authentication.AuthenticationService",
+            osgi.service;objectClass="org.wso2.carbon.business.messaging.core.authentication.AuthenticationService";requiredByComponentName="business-messaging-auth-mgt"
+        </carbon.component>
     </properties>
 
 </project>

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/authentication/AuthenticationService.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/authentication/AuthenticationService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.business.messaging.core.authentication;
+
+import org.wso2.carbon.business.messaging.core.exceptions.AuthenticationException;
+
+/**
+ * Interface to expose operations related to user authentication.
+ */
+public interface AuthenticationService {
+    /**
+     * @param userName username of user
+     * @param password password of user
+     * @return if the user credentials are valid or not
+     * @throws AuthenticationException can be thrown.
+     */
+    boolean isValidUser(String userName, String password) throws AuthenticationException;
+}

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/authentication/AuthenticationService.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/authentication/AuthenticationService.java
@@ -29,5 +29,5 @@ public interface AuthenticationService {
      * @return if the user credentials are valid or not
      * @throws AuthenticationException can be thrown.
      */
-    boolean isValidUser(String userName, String password) throws AuthenticationException;
+    boolean isValidUser(String userName, char[] password) throws AuthenticationException;
 }

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/authentication/CarbonBasedPrincipalDatabase.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/authentication/CarbonBasedPrincipalDatabase.java
@@ -80,7 +80,7 @@ public class CarbonBasedPrincipalDatabase implements PrincipalDatabase {
      * @return Principal instance
      */
     @Override
-    //TODO: Once auth JAAS component is available
+    //TODO: Once authentication component is available
     public Principal getUser(String username) {
         Principal user = null;
         return user;
@@ -136,17 +136,13 @@ public class CarbonBasedPrincipalDatabase implements PrincipalDatabase {
                 logger.error("No AuthenticationService implementation is available");
             }
         } catch (AuthenticationException e) {
-            logger.error("Error while validating user" + userName, e);
+            logger.error("Error while validating user: " + userName, e);
         }
         if (passwordCallback instanceof PlainPasswordCallback) {
             // Let the engine know if the user is authenticated or not
             ((PlainPasswordCallback) passwordCallback).setAuthenticated(isAuthenticated);
         }
 
-    }
-
-    //TODO: Once auth JAAS component is available
-    public void setPasswordFile(String passwordFile) {
     }
 
 }

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/authentication/CarbonBasedPrincipalDatabase.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/authentication/CarbonBasedPrincipalDatabase.java
@@ -122,9 +122,9 @@ public class CarbonBasedPrincipalDatabase implements PrincipalDatabase {
 
         // Given username/password
         String userName = principal.getName();
-        String password = "";
+        char[] password = new char[10];
         if (passwordCallback instanceof PlainPasswordCallback) {
-            password = ((PlainPasswordCallback) passwordCallback).getPlainPassword();
+            password = ((PlainPasswordCallback) passwordCallback).getPlainPassword().toCharArray();
         }
 
         boolean isAuthenticated = false;

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/authentication/CarbonBasedPrincipalDatabase.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/authentication/CarbonBasedPrincipalDatabase.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2005-2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+package org.wso2.carbon.business.messaging.core.authentication;
+
+import org.apache.log4j.Logger;
+import org.wso2.andes.server.security.auth.database.PrincipalDatabase;
+import org.wso2.andes.server.security.auth.sasl.AuthenticationProviderInitialiser;
+import org.wso2.andes.server.security.auth.sasl.plain.PlainInitialiser;
+import org.wso2.andes.server.security.auth.sasl.plain.PlainPasswordCallback;
+import org.wso2.carbon.business.messaging.core.exceptions.AuthenticationException;
+import org.wso2.carbon.business.messaging.core.internal.BrokerServiceDataHolder;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.login.AccountNotFoundException;
+
+/**
+ * Carbon-based principal database for Apache Qpid. This uses Carbon user manager to handle authentication.
+ */
+public class CarbonBasedPrincipalDatabase implements PrincipalDatabase {
+
+    private static final Logger logger = Logger.getLogger(CarbonBasedPrincipalDatabase.class);
+    private Map<String, AuthenticationProviderInitialiser> saslServers;
+    private AuthenticationService authenticationService;
+
+    public CarbonBasedPrincipalDatabase() {
+        saslServers = new HashMap<String, AuthenticationProviderInitialiser>();
+        //Get the registered authentication service implementation
+        authenticationService = BrokerServiceDataHolder.getInstance().getAuthenticationService();
+        // Accept Plain incoming and compare it with UM value
+        PlainInitialiser plain = new PlainInitialiser();
+        plain.initialise(this);
+
+        saslServers.put(plain.getMechanismName(), plain);
+    }
+
+    /**
+     * Get list of SASL mechanism objects. We only use PLAIN.
+     *
+     * @return List of mechanism objects
+     */
+    @Override
+    public Map<String, AuthenticationProviderInitialiser> getMechanisms() {
+        return saslServers;
+    }
+
+    @Override
+    public List<Principal> getUsers() {
+        return null;
+    }
+
+    @Override
+    public boolean deletePrincipal(Principal principal) throws AccountNotFoundException {
+        return true;
+    }
+
+    /**
+     * Create Principal instance for a valid user
+     *
+     * @param username Principal username
+     * @return Principal instance
+     */
+    @Override
+    //TODO: Once auth JAAS component is available
+    public Principal getUser(String username) {
+        Principal user = null;
+        return user;
+    }
+
+    @Override
+    public boolean verifyPassword(String principal, char[] password) throws AccountNotFoundException {
+        return true;
+    }
+
+    @Override
+    public boolean updatePassword(Principal principal, char[] password) throws AccountNotFoundException {
+        return true;
+    }
+
+    @Override
+    public boolean createPrincipal(Principal principal, char[] password) {
+        return true;
+    }
+
+    @Override
+    public void reload() throws IOException {
+    }
+
+    /**
+     * This method sets of a given principal is authenticated or not.
+     *
+     * @param principal        Principal to be authenticated
+     * @param passwordCallback Callback to set if the user is authenticated or not. This also holds user's password.
+     * @throws IOException IOException can be thrown
+     */
+    @Override
+    public void setPassword(Principal principal, PasswordCallback passwordCallback)
+            throws IOException, AccountNotFoundException {
+
+        if (principal == null) {
+            throw new IllegalArgumentException("Principal should never be null");
+        }
+
+        // Given username/password
+        String userName = principal.getName();
+        String password = "";
+        if (passwordCallback instanceof PlainPasswordCallback) {
+            password = ((PlainPasswordCallback) passwordCallback).getPlainPassword();
+        }
+
+        boolean isAuthenticated = false;
+        try {
+            //Use authenticationService interface based implementation
+            if (authenticationService != null) {
+                isAuthenticated = authenticationService.isValidUser(userName, password);
+            } else {
+                logger.error("No AuthenticationService implementation is available");
+            }
+        } catch (AuthenticationException e) {
+            logger.error("Error while validating user" + userName, e);
+        }
+        if (passwordCallback instanceof PlainPasswordCallback) {
+            // Let the engine know if the user is authenticated or not
+            ((PlainPasswordCallback) passwordCallback).setAuthenticated(isAuthenticated);
+        }
+
+    }
+
+    //TODO: Once auth JAAS component is available
+    public void setPasswordFile(String passwordFile) {
+    }
+
+}

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/exceptions/AuthenticationException.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/exceptions/AuthenticationException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.business.messaging.core.exceptions;
+
+/**
+ * AuthenticationException to handle user authentication errors.
+ */
+public class AuthenticationException extends Exception {
+
+    public AuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/AuthenticationServiceImpl.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/AuthenticationServiceImpl.java
@@ -30,9 +30,9 @@ public class AuthenticationServiceImpl implements AuthenticationService {
      */
     @Override
     //TODO: Integrate with user authentication implementation when available
-    public boolean isValidUser(String userName, String password) {
+    public boolean isValidUser(String userName, char[] password) {
 
-        if (userName.equals("admin") && password.equals("admin")) {
+        if (userName.equals("admin") && new String(password).equals("admin")) {
             return true;
         }
         return false;

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/AuthenticationServiceImpl.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/AuthenticationServiceImpl.java
@@ -29,7 +29,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
      * @return if the user credentials are valid or not.
      */
     @Override
-    //TODO: Integrate with shared JAAS component implementation
+    //TODO: Integrate with user authentication implementation when available
     public boolean isValidUser(String userName, String password) {
 
         if (userName.equals("admin") && password.equals("admin")) {

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/AuthenticationServiceImpl.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/AuthenticationServiceImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.carbon.business.messaging.core.internal;
+
+import org.wso2.carbon.business.messaging.core.authentication.AuthenticationService;
+
+/**
+ * This class implements AuthenticationService interface to provide user authentication.
+ */
+public class AuthenticationServiceImpl implements AuthenticationService {
+    /**
+     * @param userName username of user
+     * @param password password of user
+     * @return if the user credentials are valid or not.
+     */
+    @Override
+    //TODO: Integrate with shared JAAS component implementation
+    public boolean isValidUser(String userName, String password) {
+
+        if (userName.equals("admin") && password.equals("admin")) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerCoreBundleActivator.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerCoreBundleActivator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+package org.wso2.carbon.business.messaging.core.internal;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.wso2.carbon.business.messaging.core.authentication.AuthenticationService;
+
+import java.util.logging.Logger;
+
+/**
+ * BrokerCore Bundle Activator to register default implementation of Authentication service.This bundleActivator will be
+ * executed before any OSGI component.
+ */
+public class BrokerCoreBundleActivator implements BundleActivator {
+    private ServiceRegistration serviceRegistration;
+    Logger logger = Logger.getLogger(BrokerCoreBundleActivator.class.getName());
+
+    /**
+     * Register the default authentication impl provided by broker component before BrokerServiceComponent is activated.
+     *
+     * @param bundleContext
+     * @throws Exception
+     */
+    @Override
+    public void start(BundleContext bundleContext) throws Exception {
+        logger.info("BrokerCoreBundleActivator is started.");
+        serviceRegistration = bundleContext
+                .registerService(AuthenticationService.class.getName(), new AuthenticationServiceImpl(), null);
+    }
+
+    @Override
+    public void stop(BundleContext bundleContext) throws Exception {
+        logger.info("BrokerCoreBundleActivator is deactivated.");
+        serviceRegistration.unregister();
+    }
+}

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerCoreBundleActivator.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerCoreBundleActivator.java
@@ -17,12 +17,12 @@
  */
 package org.wso2.carbon.business.messaging.core.internal;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.wso2.carbon.business.messaging.core.authentication.AuthenticationService;
-
-import java.util.logging.Logger;
 
 /**
  * BrokerCore Bundle Activator to register default implementation of Authentication service.This bundleActivator will be
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
  */
 public class BrokerCoreBundleActivator implements BundleActivator {
     private ServiceRegistration serviceRegistration;
-    Logger logger = Logger.getLogger(BrokerCoreBundleActivator.class.getName());
+    private static final Log logger = LogFactory.getLog(BrokerCoreBundleActivator.class);
 
     /**
      * Register the default authentication impl provided by broker component before BrokerServiceComponent is activated.

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
@@ -420,7 +420,7 @@ public class BrokerServiceComponent implements RequiredCapabilityListener {
                     } catch (IOException e) {
                         //There will be a continuous retry effort to close the socket, if an error occurs the
                         // exception will not be propagated further
-                        log.error("Can not close the socket which is used to check the server " + "status ", e);
+                        log.error("Can not close the socket which is used to check the server status ", e);
                     }
                 }
             }

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
@@ -218,8 +218,7 @@ public class BrokerServiceComponent implements RequiredCapabilityListener {
             String error = "Invalid configuration found in a configuration file";
             log.error(error, e);
         } catch (AndesException e) {
-            String error = "An error occurred while broker startup.";
-            log.error(error, e);
+            log.error("An error occurred while broker startup", e);
         }
     }
 

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
@@ -61,10 +61,8 @@ import javax.management.ObjectName;
 import javax.sql.DataSource;
 
 /**
- * Service responsible for initializing  broker and registering data-sources and the relevant listeners
  * Service responsible for initializing  broker and registering data-sources and the relevant listeners.
  * This also acts as a capabilityListener for AuthenticationService where multiple implementations can be registered.
- *
  * @since 5.0.0
  */
 @Component(name = "org.wso2.carbon.andes.internal.BrokerServiceComponent",
@@ -132,7 +130,6 @@ public class BrokerServiceComponent implements RequiredCapabilityListener {
 
     /**
      * This will store all the auth implementations of AuthenticationService class
-     *
      * @param service implementation of Authentication Service interface.
      */
     @Reference(name = "auth.service.reference",
@@ -163,7 +160,6 @@ public class BrokerServiceComponent implements RequiredCapabilityListener {
     @Activate
     public void start(BundleContext context) {
         this.bundleContext = context;
-
     }
 
     /**
@@ -243,7 +239,6 @@ public class BrokerServiceComponent implements RequiredCapabilityListener {
 
     /**
      * This method will be called to add/register the data-sources with the broker
-     *
      * @param dataSourceService the declarative service which allows access to db instance
      */
     @Reference(name = "org.wso2.carbon.datasource.DataSourceService",

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
@@ -140,7 +140,7 @@ public class BrokerServiceComponent implements RequiredCapabilityListener {
     public void registerAuthService(AuthenticationService service) {
         authList.add(service);
         //This is required to sync the list of OSGI services known by OSGI framework and OSGI components.
-        StartupServiceUtils.updateServiceCache("business-messaging-auth-mgt", AuthenticationService.class);
+        StartupServiceUtils.updateServiceCache(COMPONENT_NAME, AuthenticationService.class);
     }
 
     /**

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceComponent.java
@@ -191,10 +191,11 @@ public class BrokerServiceComponent implements RequiredCapabilityListener {
                 if (authenticatorName.equals(service.getClass().getName())) {
                     authService = service;
                     BrokerServiceDataHolder.getInstance().setAuthenticationService(authService);
-                } else {
-                    log.error("No matching authentication implementation was found for:" + authenticatorName);
                 }
             });
+            if (BrokerServiceDataHolder.getInstance().getAuthenticationService() == null) {
+                log.error("No matching authentication implementation was found for:" + authenticatorName);
+            }
 
             // Start broker in standalone mode
             if (Modes.STANDALONE.name().equalsIgnoreCase(mode)) {

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceDataHolder.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceDataHolder.java
@@ -93,7 +93,6 @@ public class BrokerServiceDataHolder {
 
     /**
      * Set the authenticationService implementation
-     *
      * @param authenticationService service implementation of AuthenticationService interface
      */
     public void setAuthenticationService(AuthenticationService authenticationService) {
@@ -102,8 +101,7 @@ public class BrokerServiceDataHolder {
 
     /**
      * Get the registered authenticationService implementation
-     *
-     * @return
+     * @return authenticationService service implementation of AuthenticationService interface
      */
     public AuthenticationService getAuthenticationService() {
         return authenticationService;

--- a/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceDataHolder.java
+++ b/components/org.wso2.carbon.business.messaging.core/src/main/java/org/wso2/carbon/business/messaging/core/internal/BrokerServiceDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.business.messaging.core.internal;
 
+import org.wso2.carbon.business.messaging.core.authentication.AuthenticationService;
 import org.wso2.carbon.business.messaging.core.listeners.BrokerLifecycleListener;
 
 import java.util.ArrayList;
@@ -42,6 +43,10 @@ public class BrokerServiceDataHolder {
      * List of external services which will be called when the broker shuts down
      */
     private List<BrokerLifecycleListener> brokerLifecycleListeners = new ArrayList<>();
+    /**
+     * Holds the implementation of authenticationService interface
+     */
+    private AuthenticationService authenticationService;
 
     private BrokerServiceDataHolder() {
     }
@@ -84,5 +89,23 @@ public class BrokerServiceDataHolder {
      */
     public void setBrokerLifecycleListeners(List<BrokerLifecycleListener> brokerLifecycleListeners) {
         this.brokerLifecycleListeners = brokerLifecycleListeners;
+    }
+
+    /**
+     * Set the authenticationService implementation
+     *
+     * @param authenticationService service implementation of AuthenticationService interface
+     */
+    public void setAuthenticationService(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
+    }
+
+    /**
+     * Get the registered authenticationService implementation
+     *
+     * @return
+     */
+    public AuthenticationService getAuthenticationService() {
+        return authenticationService;
     }
 }

--- a/features/org.wso2.carbon.business.messaging.core.feature/src/main/resources/conf/broker.xml
+++ b/features/org.wso2.carbon.business.messaging.core.feature/src/main/resources/conf/broker.xml
@@ -26,7 +26,9 @@ expression of the property.
 
 This file is ciphertool compliant. Refer PRODUCT_HOME/repository/conf/security/cipher-text.properties for examples.-->
 <broker>
-
+    <!-- Add the relevant implementation class name of Authentication Service.By default authentication implementation
+    of broker will be used-->
+    <authenticator class="org.wso2.carbon.business.messaging.core.internal.AuthenticationServiceImpl"/>
     <coordination>
         <!-- You can override the cluster node identifier of this MB node using the nodeID. 
         If it is left as "default", the default node ID will be generated for it. (Using IP + UUID).

--- a/features/org.wso2.carbon.business.messaging.core.feature/src/main/resources/conf/qpid-config.xml
+++ b/features/org.wso2.carbon.business.messaging.core.feature/src/main/resources/conf/qpid-config.xml
@@ -60,7 +60,7 @@
     <security>
         <pd-auth-manager>
             <principal-database>
-                <class>org.wso2.andes.server.security.auth.manager.CarbonBasedPrincipalDatabase</class>
+                <class>org.wso2.carbon.business.messaging.core.authentication.CarbonBasedPrincipalDatabase</class>
                 <!--attributes>
                     <attribute>
                         <name>name</name>


### PR DESCRIPTION
This exposes AuthenticationService interface as an OSGI service where external components can register implementations.To support multiple implementations BrokerServiceComponent is updated as a capabilityListener, which would hold broker start-up until all registered implementations for AuthenticationService are available. Once all capabilities are available, it will match the implementation class name provided in broker.xml (<authenticator class="'/>) and set the correct implementation.