### PR TITLE
Upgrade Carbon-Kernel to 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@
             </dependency>
             <!--Securevault-->
             <dependency>
-                <groupId>org.wso2.securevault</groupId>
-                <artifactId>org.wso2.securevault</artifactId>
+                <groupId>org.wso2.carbon.secvault</groupId>
+                <artifactId>org.wso2.carbon.secvault</artifactId>
                 <version>${org.wso2.securevault.version}</version>
             </dependency>
             <dependency>
@@ -493,11 +493,11 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
-        <carbon.kernel.version>5.2.0-beta</carbon.kernel.version>
-        <carbon.datasources.version>1.1.2</carbon.datasources.version>
+        <carbon.kernel.version>5.2.0</carbon.kernel.version>
+        <carbon.datasources.version>1.1.3</carbon.datasources.version>
         <carbon.utils.version>2.0.2</carbon.utils.version>
         <carbon.utils.package.import.version.range>[2.0.0,3.0.0)</carbon.utils.package.import.version.range>
-        <carbon.jndi.version>1.0.3</carbon.jndi.version>
+        <carbon.jndi.version>1.0.4</carbon.jndi.version>
         <!-- ******************************** -->
         <version.log4j>1.2.13</version.log4j>
         <commons-logging.version>1.1.1</commons-logging.version>
@@ -537,12 +537,13 @@
         <netty-all.version>4.0.23.wso2v1</netty-all.version>
         <orbit.version.h2.engine>1.2.140.wso2v3</orbit.version.h2.engine>
         <orbit.version.xmlschema>1.4.7.wso2v2</orbit.version.xmlschema>
-        <org.wso2.securevault.version>1.0.0</org.wso2.securevault.version>
+        <org.wso2.securevault.version>5.0.8</org.wso2.securevault.version>
         <junit.version>3.8.2</junit.version>
         <commons-codec.version>1.3.0.wso2v1</commons-codec.version>
         <gson.version>2.2.4</gson.version>
         <testng.version>6.3.1</testng.version>
-        <carbon.config.version>2.0.0</carbon.config.version>
+        <carbon.config.version>2.1.2</carbon.config.version>
+        <carbon.metrics.version>2.3.2</carbon.metrics.version>
 
         <msf4j.version>2.2.2</msf4j.version>
         <msf4j.import.version.range>[2.0.0, 3.0.0)</msf4j.import.version.range>


### PR DESCRIPTION
## Purpose
Upgrade Carbon-Kernel and related dependencies to latest

## Approach
Following components are updated,

- Carbon-Kernel    5.2.0
- Carbon-Secvault    5.0.8
- Carbon-Metrics     2.3.2
- Carbon-Datasources 1.1.3
- Carbon-Jndi        1.0.4
- Carbon-Config      2.1.2