### PR TITLE
Modify broker.xml to fix ei-1914

### DIFF
--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -483,6 +483,10 @@ This file is ciphertool compliant. Refer PRODUCT_HOME/repository/conf/security/c
             buffer of slots which can be allocated to a slot delivery worker in the near future. The specified
             number of slots from the last assigned should not be touched by the periodic deletion task.-->
             <safetySlotCount>3</safetySlotCount>
+            
+            <!--By default expired messages are removed from broker. Instead, to move expired messages to 
+            Dead Letter Channel make this to true-->
+            <moveExpiredMessagesToDLC>false</moveExpiredMessagesToDLC>
         </messageExpiration>
 
     </performanceTuning>


### PR DESCRIPTION
## Purpose
> Add new configuration to broker. xml

            
```
            <!--By default expired messages are removed from broker. Instead, to move expired messages to 
            Dead Letter Channel make this to true-->
            <moveExpiredMessagesToDLC>false</moveExpiredMessagesToDLC>
```
## Goals
> Fix ei-1914

## Approach
> Modify the configuration to enable feature descried at the issue 

## User stories
> N/A

## Release note
> N/A

## Documentation
> https://docs.wso2.com/display/EI611/Implementing+Message+Expiration

This page should have the description. 

## Training
> N/A

## Certification
> N/A. It is a small feature. 

## Marketing
> MB now supports moving expired messages to DLC. They are not lost. You can later route back to origin queue or a different queue. 

## Automation tests
 - Unit tests 
   > Not added. Reused existing methods
 - Integration tests
   > Not added. Add when MB test suite is moved to EI

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/wso2/andes/pull/965

## Migrations (if applicable)
> N/A

## Test environment
> Java 8

## Learning
> N/A