### PR TITLE
Improve Re-route All in DLC

### DIFF
--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_message_destinations_list_retrieve_ajaxprocessor.jsp
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_message_destinations_list_retrieve_ajaxprocessor.jsp
@@ -16,9 +16,10 @@
         String[] durableQueues = stub.getNamesOfAllDurableQueues();
         // Creating a string with all destinations with delimiter as #
         for (String queueName : durableQueues) {
-            destinationList += queueName + "#";
+            if (!DLCQueueUtils.isDeadLetterQueue(queueName)) {
+                destinationList += queueName + "#";
+            }
         }
-
         // We can remove the # tag only if the destinationList is not empty
         if (destinationList.length() > 0) {
             //remove the last #

--- a/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_messages_list.jsp
+++ b/components/andes/org.wso2.carbon.andes.ui/src/main/resources/web/queues/dlc_messages_list.jsp
@@ -210,8 +210,6 @@
     </script>
 
  <%
-         boolean allowReRouteAllInDLC = AndesConfigurationManager.readValue(
-                                                                            AndesConfiguration.MANAGEMENT_CONSOLE_ALLOW_REREOUTE_ALL_IN_DLC);
          String destinationFilter = StringUtils.trimToEmpty(request.getParameter("destinationFilter"));
 
          AndesAdminServiceStub stub = UIUtils.getAndesAdminServiceStub(config, session, request);
@@ -386,13 +384,12 @@
                                    class="icon-link"
                                    onclick="doReRouteMessages('<%=nameOfQueue%>')">ReRoute</a>
                             </th>
-                                <% if (allowReRouteAllInDLC && (null != filteredMsgArray) && (filteredMsgArray.length > 0)) {%>
-                                    <th align="right">
-                                        <a style="background-image: url(images/move.gif);"
-                                           class="icon-link"
-                                           onclick="doReRouteAllMessages('<%=nameOfQueue%>')">ReRoute All Messages</a>
-                                    </th>
-                                <% } %>
+
+                                <th align="right">
+                                    <a style="background-image: url(images/move.gif);"
+                                        class="icon-link"
+                                        onclick="doReRouteAllMessages('<%=nameOfQueue%>')">ReRoute All Messages</a>
+                                </th>
                             <% } else { %>
                             <th align="right">
                                 <a style="background-image: url(images/move.gif);"

--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -505,9 +505,6 @@ This file is ciphertool compliant. Refer PRODUCT_HOME/repository/conf/security/c
         * NOTE : Increasing this value could cause delays when loading the message content page.-->
         <maximumMessageDisplayLength>100000</maximumMessageDisplayLength>
 
-        <!--Enable users to reroute all messages from a specific destination(queue or durable topic) to a specific
-        queue.-->
-        <allowReRouteAllInDLC>false</allowReRouteAllInDLC>
     </managementConsole>
 
     <!-- Memory and resource exhaustion is something we should prevent and recover from.

--- a/pom.xml
+++ b/pom.xml
@@ -682,9 +682,9 @@
         <carbon.messaging.version>3.2.50-SNAPSHOT</carbon.messaging.version>
         <carbon.identity.version>5.11.256</carbon.identity.version>
         <carbon.identity.oauth.stub.version>6.0.3</carbon.identity.oauth.stub.version>
-        <andes.dependency.version>3.2.63</andes.dependency.version>
-        <andes.export.version>3.2.63</andes.export.version>
-        <andes.import.version>3.2.63</andes.import.version>
+        <andes.dependency.version>3.2.64</andes.dependency.version>
+        <andes.export.version>3.2.64</andes.export.version>
+        <andes.import.version>3.2.64</andes.import.version>
         <carbon.kernel.version>4.4.32</carbon.kernel.version>
         <carbon.platform.package.export.version>4.4.0</carbon.platform.package.export.version>
         <carbon.platform.package.import.version.range>[4.4.0, 4.5.0)


### PR DESCRIPTION
Enables the functionality of re-routing all messages that belong to a
queue by default as opposed to a configuration in broker.xml. Also
blocks the DLC queue from being listed under the queue list.
Resolves: https://github.com/wso2/product-ei/issues/2322

## Related PRs
https://github.com/wso2/andes/pull/980