### PR TITLE
Remove Hazelcast

### DIFF
--- a/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/resources/conf/broker.xml
@@ -57,8 +57,7 @@ This file is ciphertool compliant. Refer PRODUCT_HOME/repository/conf/security/c
         </rdbmsBasedCoordination>
 
         <!-- Enabling this will make the cluster notifications such as Queue changes(additions and deletions),
-        Subscription changes, etc. sent within the cluster be synchronized using RDBMS. If set to false, Hazelcast
-        will be used for this purpose.-->
+        Subscription changes, etc. sent within the cluster be synchronized using RDBMS. -->
         <rdbmsBasedClusterEventSynchronization enabled="true">
 
             <!--Specifies the interval at which, the cluster events will be read from the database. Needs to be

--- a/pom.xml
+++ b/pom.xml
@@ -706,7 +706,7 @@
         <carbon.messaging.version>3.3.26-SNAPSHOT</carbon.messaging.version>
         <carbon.identity.framework.version>5.15.17</carbon.identity.framework.version>
         <carbon.identity.oauth.stub.version>6.0.103</carbon.identity.oauth.stub.version>
-        <andes.dependency.version>3.3.23</andes.dependency.version>
+        <andes.dependency.version>3.3.24</andes.dependency.version>
         <carbon.kernel.version>4.5.3</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.platform.package.export.version>4.4.0</carbon.platform.package.export.version>

--- a/pom.xml
+++ b/pom.xml
@@ -351,6 +351,12 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.core</artifactId>
                 <version>${carbon.kernel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.wso2.orbit.com.hazelcast</groupId>
+                        <artifactId>hazelcast</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>


### PR DESCRIPTION
## Purpose
As we have deprecated the Hazelcast based distributed caching use cases in APIM, removing the Hazelcast dependency from carbon-business-messaging repository.

Fixes wso2/api-manager#475