### PR TITLE
[APIM 4.4.0] Upgrade protobuf-java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -815,7 +815,7 @@
 		<javassist.version>3.18.1-GA</javassist.version>
 		<antlr4-runtime.version>4.5.1</antlr4-runtime.version>
 		<sqlite-jdbc.version>3.44.1.0</sqlite-jdbc.version>
-		<protobuf-java.version>3.21.12</protobuf-java.version>
+		<protobuf-java.version>3.25.5</protobuf-java.version>
         <org.apache.commons.pool.version>2.4.2</org.apache.commons.pool.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <maven.scr.plugin.version>1.26.0</maven.scr.plugin.version>


### PR DESCRIPTION
### Purpose

Upgrades the protobuf-java version to non-vulnerable 3.25.5.