### PR TITLE
Upgrade commons-beanutils version from 1.9.4.wso2v1 to 1.11.0.wso2v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -736,7 +736,7 @@
         <version.jettison>1.3.4</version.jettison>
         <orbit.version.jettison>1.3.4.wso2v1</orbit.version.jettison>
         <orbit.version.hsqldb>1.8.0.7wso2v1</orbit.version.hsqldb>
-        <orbit.version.commons.beanutils>1.9.4.wso2v1</orbit.version.commons.beanutils>
+        <orbit.version.commons.beanutils>1.11.0-wso2v1</orbit.version.commons.beanutils>
         <orbit.version.poi>3.9.0.wso2v1</orbit.version.poi>
         <orbit.version.commons.lang>2.6.0.wso2v1</orbit.version.commons.lang>
         <orbit.version.commons.collection>3.2.0.wso2v1</orbit.version.commons.collection>
@@ -781,7 +781,7 @@
         <commons-cli.version>1.2.0</commons-cli.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <commons-digester.version>1.8.1</commons-digester.version>
-        <commons-beanutils.version>1.9.4</commons-beanutils.version>
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <geronimo-jms_1.1_spec.version>1.1.0</geronimo-jms_1.1_spec.version>
         <stratos.common.version>2.2.0</stratos.common.version>
         <netty-all.version>4.0.23.wso2v1</netty-all.version>


### PR DESCRIPTION
This PR upgrades Apache Commons BeanUtils to the latest stable version to improve security, compatibility, and performance.

### Changes Made

**Commons Libraries:**
- **commons-beanutils.version**: `1.9.4.wso2v1` → `1.11.0-wso2v1`

Related Issue : https://github.com/wso2/api-manager/issues/3870