### PR TITLE
Upgrade commons-config version

### DIFF
--- a/components/andes/org.wso2.carbon.andes.authorization/pom.xml
+++ b/components/andes/org.wso2.carbon.andes.authorization/pom.xml
@@ -55,8 +55,8 @@
             <artifactId>org.wso2.carbon.andes.authentication</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/components/andes/org.wso2.carbon.andes.authorization/src/main/java/org/wso2/carbon/andes/authorization/service/andes/AndesAuthorizationPlugin.java
+++ b/components/andes/org.wso2.carbon.andes.authorization/src/main/java/org/wso2/carbon/andes/authorization/service/andes/AndesAuthorizationPlugin.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.andes.authorization.service.andes;
 
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.configuration.qpid.plugins.ConfigurationPlugin;

--- a/components/andes/org.wso2.carbon.andes.authorization/src/main/java/org/wso2/carbon/andes/authorization/service/andes/AndesAuthorizationPluginConfiguration.java
+++ b/components/andes/org.wso2.carbon.andes.authorization/src/main/java/org/wso2/carbon/andes/authorization/service/andes/AndesAuthorizationPluginConfiguration.java
@@ -18,8 +18,8 @@
 
 package org.wso2.carbon.andes.authorization.service.andes;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.wso2.andes.configuration.qpid.plugins.ConfigurationPlugin;
 import org.wso2.andes.configuration.qpid.plugins.ConfigurationPluginFactory;
 import java.util.Arrays;

--- a/features/andes/org.wso2.carbon.andes.server.feature/pom.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/pom.xml
@@ -136,8 +136,8 @@
 		    <artifactId>protobuf-java</artifactId>
 		</dependency>
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs.wso2</groupId>
@@ -162,6 +162,14 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
         </dependency>
 
         <!--MQTT related dependencies-->
@@ -328,10 +336,12 @@
 								<bundleDef>org.xerial:sqlite-jdbc:${sqlite-jdbc.version}</bundleDef>
 								<bundleDef>com.google.protobuf:protobuf-java:${protobuf-java.version}</bundleDef>
                                 <bundleDef>commons-cli.wso2:commons-cli</bundleDef>
-                                <bundleDef>commons-configuration:commons-configuration</bundleDef>
+                                <bundleDef>org.apache.commons:commons-configuration2</bundleDef>
                                 <bundleDef>commons-digester.wso2:commons-digester</bundleDef>
                                 <bundleDef>org.wso2.orbit.commons-beanutils:commons-beanutils</bundleDef>
                                 <bundleDef>com.google.guava:guava</bundleDef>
+                                <bundleDef>jakarta.servlet:jakarta.servlet-api</bundleDef>
+                                <bundleDef>org.apache.commons:commons-text</bundleDef>
                                 <bundleDef>io.netty.wso2:netty-all</bundleDef>
                                 <bundleDef>libthrift.wso2:libthrift</bundleDef>
                                 <bundleDef>org.apache.axis2.transport:axis2-transport-jms:${axis2.transport.version}</bundleDef>

--- a/pom.xml
+++ b/pom.xml
@@ -364,14 +364,25 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-configuration</groupId>
-                <artifactId>commons-configuration</artifactId>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
                 <version>${commons-configuration.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.commons</groupId>
                 <artifactId>org.wso2.carbon.event.core</artifactId>
                 <version>${carbon.commons.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${commons-text.version}</version>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>
@@ -706,7 +717,7 @@
         <carbon.messaging.version>3.3.36-SNAPSHOT</carbon.messaging.version>
         <carbon.identity.framework.version>5.15.17</carbon.identity.framework.version>
         <carbon.identity.oauth.stub.version>6.0.103</carbon.identity.oauth.stub.version>
-        <andes.dependency.version>3.3.33</andes.dependency.version>
+        <andes.dependency.version>3.3.36-SNAPSHOT</andes.dependency.version>
         <carbon.kernel.version>4.5.3</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <carbon.platform.package.export.version>4.4.0</carbon.platform.package.export.version>
@@ -714,6 +725,9 @@
         </carbon.platform.package.import.version.range>
         <carbon.p2.plugin.version>1.5.4</carbon.p2.plugin.version>
         <xmlsec.version>1.4.2-patched</xmlsec.version>
+        <jakarta.servlet.api.version>5.0.0</jakarta.servlet.api.version>
+        <commons-text.version>1.13.1</commons-text.version>
+
         <!-- Apache  -->
         <orbit.version.neethi>2.0.4.wso2v4</orbit.version.neethi>
         <exp.pkg.version.neethi>2.0.4.wso2v4</exp.pkg.version.neethi>
@@ -736,7 +750,6 @@
         <version.jettison>1.3.4</version.jettison>
         <orbit.version.jettison>1.3.4.wso2v1</orbit.version.jettison>
         <orbit.version.hsqldb>1.8.0.7wso2v1</orbit.version.hsqldb>
-        <orbit.version.commons.beanutils>1.9.4.wso2v1</orbit.version.commons.beanutils>
         <orbit.version.poi>3.9.0.wso2v1</orbit.version.poi>
         <orbit.version.commons.lang>2.6.0.wso2v1</orbit.version.commons.lang>
         <orbit.version.commons.collection>3.2.0.wso2v1</orbit.version.commons.collection>
@@ -751,7 +764,7 @@
         <orbit.version.poi>3.9.0.wso2v1</orbit.version.poi>
         <orbit.version.h2.engine>2.2.224.wso2v2</orbit.version.h2.engine>
         <orbit.version.commons.httpclient>3.1.0.wso2v2</orbit.version.commons.httpclient>
-        <orbit.version.commons.fileuploader>1.2.0.wso2v1</orbit.version.commons.fileuploader>
+        <orbit.version.commons.fileuploader>1.6.0.wso2v1</orbit.version.commons.fileuploader>
         <orbit.version.org.apache.geronimo.components.wso2.geronimo-connector>2.0.1.wso2v1
         </orbit.version.org.apache.geronimo.components.wso2.geronimo-connector>
         <orbit.version.org.apache.geronimo.components.wso2.geronimo-transaction>2.0.1.wso2v1
@@ -779,9 +792,9 @@
         <!-- XML Schema -->
         <orbit.version.xmlschema>1.4.7.wso2v2</orbit.version.xmlschema>
         <commons-cli.version>1.2.0</commons-cli.version>
-        <commons-configuration.version>1.10</commons-configuration.version>
+        <commons-configuration.version>2.12.0</commons-configuration.version>
         <commons-digester.version>1.8.1</commons-digester.version>
-        <commons-beanutils.version>1.9.4</commons-beanutils.version>
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <geronimo-jms_1.1_spec.version>1.1.0</geronimo-jms_1.1_spec.version>
         <stratos.common.version>2.2.0</stratos.common.version>
         <netty-all.version>4.0.23.wso2v1</netty-all.version>


### PR DESCRIPTION
This pull request updates several dependencies across the project, focusing primarily on upgrading from `commons-configuration` to `commons-configuration2`, and adding new dependencies for `jakarta.servlet-api` and `commons-text`. It also updates some dependency versions to improve compatibility and maintainability.

**Dependency upgrades and replacements:**

* Replaced `commons-configuration` with `org.apache.commons:commons-configuration2` in multiple `pom.xml` files to use the newer version of the library. [[1]](diffhunk://#diff-0bdb007b7e0a3a4c73ce4cbc63df5aaeef28e1767c2fb7528e668c86579787b4L58-R59) [[2]](diffhunk://#diff-f7633302f4c1d1731c5e1831feec99659d9e9a2f05fa549f9c5facd12c0e5818L139-R140) [[3]](diffhunk://#diff-f7633302f4c1d1731c5e1831feec99659d9e9a2f05fa549f9c5facd12c0e5818L331-R344) [[4]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L367-R386)
* Updated Java imports in `AndesAuthorizationPlugin.java` and `AndesAuthorizationPluginConfiguration.java` to use `commons-configuration2` classes and exceptions. [[1]](diffhunk://#diff-00b4f1b8d58cccfc8b5924b5f5032e16bdba2d9deca070922957acdb19125d58L21-R21) [[2]](diffhunk://#diff-79647352eef23114ceb54fdb89a49ba61ceeb5711624081d309f5e707ec26813L21-R22)
* Bumped `commons-configuration.version` from `1.10` to `2.12.0` in the root `pom.xml`.

**New dependencies added:**

* Added `jakarta.servlet:jakarta.servlet-api` and `org.apache.commons:commons-text` as dependencies in the root and feature module `pom.xml` files, with corresponding version properties. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L367-R386) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L709-R730) [[3]](diffhunk://#diff-f7633302f4c1d1731c5e1831feec99659d9e9a2f05fa549f9c5facd12c0e5818R166-R173) [[4]](diffhunk://#diff-f7633302f4c1d1731c5e1831feec99659d9e9a2f05fa549f9c5facd12c0e5818L331-R344)

**Other dependency version updates:**

* Updated `andes.dependency.version` to `3.3.36-SNAPSHOT`.
* Updated `commons-beanutils.version` to `1.11.0` and `commons.fileuploader` to `1.6.0.wso2v1`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L754-R767) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L782-R797)