### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -720,12 +720,10 @@
         <imp.pkg.version.neethi>[2.0.4.wso2v4, 3.0.0)</imp.pkg.version.neethi>
         <commons-lang.version>2.6</commons-lang.version>
         <!-- Apache Axiom -->
-        <orbit.version.axiom>1.2.11-wso2v16</orbit.version.axiom>
-        <exp.pkg.version.axiom>1.2.11-wso2v16</exp.pkg.version.axiom>
+        <orbit.version.axiom>1.2.11-wso2v29</orbit.version.axiom>
         <imp.pkg.version.axiom>[1.2.11, 1.3.0)</imp.pkg.version.axiom>
-        <version.axiom>1.2.11-wso2v16</version.axiom>
         <!-- Apache Axis2 -->
-        <orbit.version.axis2>1.6.1-wso2v50</orbit.version.axis2>
+        <orbit.version.axis2>1.6.1-wso2v105</orbit.version.axis2>
         <imp.pkg.version.axis2>[1.6.1, 1.7.0)</imp.pkg.version.axis2>
         <!-- Wss4j -->
         <version.wss4j>1.5.11-wso2v18</version.wss4j>
@@ -797,7 +795,7 @@
         <codahale.metrics.version>3.0.2</codahale.metrics.version>
         <metrics-core.version>2.0.3.wso2v1</metrics-core.version>
         <org.apache.felix.main.version>2.0.5</org.apache.felix.main.version>
-        <axis2.transport.version>2.0.0-wso2v49</axis2.transport.version>
+        <axis2.transport.version>2.0.0-wso2v73</axis2.transport.version>
         <carbon.metrics.version>1.3.7</carbon.metrics.version>
         <gson.version>2.8.5</gson.version>
         <gson.version.range>[2.0.0, 3.0.0)</gson.version.range>


### PR DESCRIPTION
## Purpose

This PR adds the following dependency version upgrades:

* Upgraded `orbit.version.axiom` from `1.2.11-wso2v16` to `1.2.11-wso2v29` to use a newer version of the Apache Axiom library.
* Upgraded `orbit.version.axis2` from `1.6.1-wso2v50` to `1.6.1-wso2v105` for the Apache Axis2 library.
* Upgraded `axis2.transport.version` from `2.0.0-wso2v49` to `2.0.0-wso2v73` for Axis2 transport modules.
