### PR TITLE
[master] Upgrade antlr4 dependency

### DIFF
--- a/features/andes/org.wso2.carbon.andes.server.feature/pom.xml
+++ b/features/andes/org.wso2.carbon.andes.server.feature/pom.xml
@@ -124,7 +124,7 @@
 		    <artifactId>javassist</artifactId>
 		</dependency>
 		<dependency>
-		    <groupId>org.antlr</groupId>
+		    <groupId>org.wso2.orbit.org.antlr</groupId>
 		    <artifactId>antlr4-runtime</artifactId>
 		</dependency>
 		<dependency>
@@ -332,7 +332,7 @@
 								<bundleDef>com.esotericsoftware:reflectasm:${reflectasm.version}</bundleDef>
 								<bundleDef>org.ow2.asm:asm:${asm.version}</bundleDef>
 								<bundleDef>org.javassist:javassist:${javassist.version}</bundleDef>
-								<bundleDef>org.antlr:antlr4-runtime:${antlr4-runtime.version}</bundleDef>
+								<bundleDef>org.wso2.orbit.org.antlr:antlr4-runtime:${antlr4-runtime.version}</bundleDef>
 								<bundleDef>org.xerial:sqlite-jdbc:${sqlite-jdbc.version}</bundleDef>
 								<bundleDef>com.google.protobuf:protobuf-java:${protobuf-java.version}</bundleDef>
                                 <bundleDef>commons-cli.wso2:commons-cli</bundleDef>

--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
 			    <version>${javassist.version}</version>
 			</dependency>
 			<dependency>
-			    <groupId>org.antlr</groupId>
+			    <groupId>org.wso2.orbit.org.antlr</groupId>
 			    <artifactId>antlr4-runtime</artifactId>
 			    <version>${antlr4-runtime.version}</version>
 			</dependency>
@@ -824,7 +824,7 @@
 		<reflectasm.version>1.11.9</reflectasm.version>
 		<asm.version>5.2</asm.version>
 		<javassist.version>3.18.1-GA</javassist.version>
-		<antlr4-runtime.version>4.5.1</antlr4-runtime.version>
+		<antlr4-runtime.version>4.7.2.wso2v1</antlr4-runtime.version>
 		<sqlite-jdbc.version>3.44.1.0</sqlite-jdbc.version>
 		<protobuf-java.version>3.25.5</protobuf-java.version>
         <org.apache.commons.pool.version>2.4.2</org.apache.commons.pool.version>


### PR DESCRIPTION
This pull request updates the ANTLR runtime dependency throughout the project to use a WSO2 repackaged version at a newer version. 

Dependency management updates:

* Updated the `antlr4-runtime` dependency in both the root `pom.xml` and `features/andes/org.wso2.carbon.andes.server.feature/pom.xml` to use the `org.wso2.orbit.org.antlr` group instead of the upstream `org.antlr` group.
* Changed the version of `antlr4-runtime` from `4.5.1` to `4.7.2.wso2v1` in the root `pom.xml`, ensuring the use of a WSO2-maintained and updated artifact.

Bundle definition updates:

* Updated the bundle definition for `antlr4-runtime` in `features/andes/org.wso2.carbon.andes.server.feature/pom.xml` to use the new group and version.

Related Issue:
- https://github.com/wso2/api-manager/issues/4919